### PR TITLE
Make a return type compatible with React 17

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -80,7 +80,7 @@ export const MenuItem = <C extends MenuItemElement = "button">({
   onClick: onClickProp,
   disabled,
   ...props
-}: Props<C>): ReactNode => {
+}: Props<C>): Exclude<ReactNode, undefined> => {
   const Component = as ?? ("button" as ElementType);
   const context = useContext(MenuContext);
 


### PR DESCRIPTION
We really need to put a CI job in place to check our types against React 17 as long as we continue to support it, but for now let's fix this isolated type issue. (In React 17, undefined is not a valid return type for a functional component.)