### PR TITLE
Avoid conditional export for `./dist/style.css`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,7 @@
       "types": "./dist/index.d.ts",
       "style": "./dist/style.css"
     },
-    "./dist/style.css": {
-      "require": "./dist/style.css",
-      "import": "./dist/style.css"
-    }
+    "./dist/style.css": "./dist/style.css"
   },
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
For some reason that I don't entirely understand, the conditional export here seems to upset postcss-loader (https://github.com/element-hq/element-web/issues/23595#issuecomment-1877670351) -- possibly because this is neither a cjs nor an es6 import. Since both `require` and `import` point to the same file, we might as well make it unconditional.