### PR TITLE
Tooltip: Remove deprecated 'shortcut' prop

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 New Vector Ltd
+Copyright 2023-2024 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,10 +36,6 @@ type TooltipProps = {
    * The tooltip caption
    */
   caption?: string;
-  /**
-   * @deprecated replaced by `caption`
-   */
-  shortcut?: string;
   /**
    * The side where the tooltip is rendered
    * @default bottom
@@ -96,7 +92,6 @@ export const Tooltip = ({
   children,
   label,
   caption,
-  shortcut,
   side = "bottom",
   align = "center",
   onEscapeKeyDown,
@@ -128,9 +123,9 @@ export const Tooltip = ({
                 using the text color secondary on a solid dark background. 
                 This is temporary and should only remain until we figure out 
                 the approach to on-solid tokens */}
-            {(caption || shortcut) && (
+            {caption && (
               <span className={classNames(styles.caption, "cpd-theme-dark")}>
-                {caption ?? shortcut}
+                {caption}
               </span>
             )}
             <Arrow width={10} height={6} className={styles.arrow} />


### PR DESCRIPTION
Since there is [another breaking change to tooltips planned](https://github.com/element-hq/compound-web/pull/137), this is a good opportunity to clean up this deprecated prop.