### PR TITLE
`Icon` in `MenuItem` can be a `ReactNode`

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-form": "^0.0.3",
     "@radix-ui/react-separator": "^1.0.3",
+    "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.0.6",
     "classnames": "^2.3.2",
     "graphemer": "^1.4.0",

--- a/src/components/Menu/MenuItem.stories.tsx
+++ b/src/components/Menu/MenuItem.stories.tsx
@@ -96,6 +96,17 @@ export const CriticalDisabled = {
   },
 };
 
+function SimpleComponent() {
+  return <div style={{ height: 24, width: 48, backgroundColor: "teal" }} />;
+}
+
+export const IconIsComponent = {
+  args: {
+    ...Primary.args,
+    Icon: <SimpleComponent />,
+  },
+};
+
 export const WithoutLabel = {
   args: {
     ...Primary.args,

--- a/src/components/Menu/MenuItem.stories.tsx
+++ b/src/components/Menu/MenuItem.stories.tsx
@@ -96,8 +96,13 @@ export const CriticalDisabled = {
   },
 };
 
-function SimpleComponent() {
-  return <div style={{ height: 24, width: 48, backgroundColor: "teal" }} />;
+function SimpleComponent(props: object) {
+  return (
+    <div
+      style={{ height: 24, width: 48, backgroundColor: "teal" }}
+      {...props}
+    />
+  );
 }
 
 export const IconIsComponent = {

--- a/src/components/Menu/MenuItem.test.tsx
+++ b/src/components/Menu/MenuItem.test.tsx
@@ -32,6 +32,7 @@ const {
   Critical,
   PrimaryDisabled,
   CriticalDisabled,
+  IconIsComponent,
   WithALongLabel,
   WithALongLabelAndChildren,
 } = composeStories(stories);
@@ -66,6 +67,11 @@ describe("MenuItem", () => {
         Imagine that there might be a volume slider here in place of the label
       </MenuItem>,
     );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders with an component as an Icon", () => {
+    const { asFragment } = render(<IconIsComponent />);
     expect(asFragment()).toMatchSnapshot();
   });
 

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -19,6 +19,8 @@ import React, {
   ComponentPropsWithoutRef,
   ComponentType,
   ElementType,
+  isValidElement,
+  ReactNode,
   SVGAttributes,
   useCallback,
   useContext,
@@ -43,7 +45,7 @@ type Props<C extends MenuItemElement> = {
   /**
    * The icon to show on this menu item.
    */
-  Icon: ComponentType<SVGAttributes<SVGElement>>;
+  Icon: ComponentType<SVGAttributes<SVGElement>> | ReactNode;
   /**
    * The label to show on this menu item.
    */
@@ -100,6 +102,10 @@ export const MenuItem = <C extends MenuItemElement = "button">({
     [context, onSelect],
   );
 
+  const iconIsReactElement = isValidElement(Icon);
+  const componentIcon = Icon as ReactNode;
+  const SvgIcon = Icon as ComponentType<SVGAttributes<SVGElement>>;
+
   const content = (
     <Component
       role="menuitem"
@@ -113,7 +119,17 @@ export const MenuItem = <C extends MenuItemElement = "button">({
       onClick={onClick}
       disabled={disabled}
     >
-      <Icon width={24} height={24} className={styles.icon} aria-hidden={true} />
+      {iconIsReactElement ? (
+        <div className={styles.icon}>{componentIcon}</div>
+      ) : (
+        <SvgIcon
+          width={24}
+          height={24}
+          className={styles.icon}
+          aria-hidden={true}
+        />
+      )}
+
       {label !== null && (
         <Text className={styles.label} size="md" weight="medium" as="span">
           {label}

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -29,6 +29,7 @@ import styles from "./MenuItem.module.css";
 import { Text } from "../Typography/Text";
 import ChevronRightIcon from "@vector-im/compound-design-tokens/icons/chevron-right.svg";
 import { MenuContext } from "./MenuContext";
+import { Slot } from "@radix-ui/react-slot";
 
 type MenuItemElement = "button" | "label" | "a" | "div";
 
@@ -44,6 +45,7 @@ type Props<C extends MenuItemElement> = {
   className?: string;
   /**
    * The icon to show on this menu item.
+   * When `Icon` is a ReactNode, it should spread the props
    */
   Icon: ComponentType<SVGAttributes<SVGElement>> | ReactNode;
   /**
@@ -120,7 +122,7 @@ export const MenuItem = <C extends MenuItemElement = "button">({
       disabled={disabled}
     >
       {iconIsReactElement ? (
-        <div className={styles.icon}>{componentIcon}</div>
+        <Slot className={styles.icon}>{componentIcon}</Slot>
       ) : (
         <SvgIcon
           width={24}

--- a/src/components/Menu/__snapshots__/MenuItem.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/MenuItem.test.tsx.snap
@@ -441,11 +441,8 @@ exports[`MenuItem > renders with an component as an Icon 1`] = `
     >
       <div
         class="_icon_831119"
-      >
-        <div
-          style="height: 24px; width: 48px; background-color: teal;"
-        />
-      </div>
+        style="height: 24px; width: 48px; background-color: teal;"
+      />
       <span
         class="_typography_489030 _font-body-md-medium_489030 _label_831119"
       >

--- a/src/components/Menu/__snapshots__/MenuItem.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/MenuItem.test.tsx.snap
@@ -429,6 +429,52 @@ exports[`MenuItem > renders with a child 1`] = `
 </DocumentFragment>
 `;
 
+exports[`MenuItem > renders with an component as an Icon 1`] = `
+<DocumentFragment>
+  <div
+    style="width: 300px;"
+  >
+    <button
+      class="_item_831119 _interactive_831119"
+      data-kind="primary"
+      role="menuitem"
+    >
+      <div
+        class="_icon_831119"
+      >
+        <div
+          style="height: 24px; width: 48px; background-color: teal;"
+        />
+      </div>
+      <span
+        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+      >
+        Menu item
+      </span>
+      <svg
+        aria-hidden="true"
+        class="_nav-hint_831119"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8.70005 17.3C8.51672 17.1167 8.42505 16.8834 8.42505 16.6C8.42505 16.3167 8.51672 16.0834 8.70005 15.9L12.6 12L8.70005 8.10005C8.51672 7.91672 8.42505 7.68338 8.42505 7.40005C8.42505 7.11672 8.51672 6.88338 8.70005 6.70005C8.88338 6.51672 9.11672 6.42505 9.40005 6.42505C9.68338 6.42505 9.91672 6.51672 10.1 6.70005L14.7 11.3C14.8 11.4 14.8709 11.5084 14.9125 11.625C14.9542 11.7417 14.975 11.8667 14.975 12C14.975 12.1334 14.9542 12.2584 14.9125 12.375C14.8709 12.4917 14.8 12.6 14.7 12.7L10.1 17.3C9.91672 17.4834 9.68338 17.575 9.40005 17.575C9.11672 17.575 8.88338 17.4834 8.70005 17.3Z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="_typography_489030 _font-body-sm-regular_489030"
+      >
+        99
+      </span>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`MenuItem > renders without a label 1`] = `
 <DocumentFragment>
   <button

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,7 +2033,7 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-primitive" "1.0.3"
 
-"@radix-ui/react-slot@1.0.2":
+"@radix-ui/react-slot@1.0.2", "@radix-ui/react-slot@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.2.tgz#a9ff4423eade67f501ffb32ec22064bc9d3099ab"
   integrity sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==


### PR DESCRIPTION
This PR allows to use a custom component as an `Icon` in the `MenuItem`.

For example, a nice teal rectangle:
<img width="308" alt="image" src="https://github.com/element-hq/compound-web/assets/2621378/bb4a88a9-78f7-43d2-b67c-1d0ccfff779b">
