### PR TITLE
Fix `Menu` focus after closing

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -119,7 +119,17 @@ export const Menu: FC<Props> = ({
     <Root open={open} onOpenChange={onOpenChange}>
       <Trigger asChild>{trigger}</Trigger>
       <Portal>
-        <Content asChild side={side} align={align} sideOffset={8}>
+        <Content
+          asChild
+          side={side}
+          align={align}
+          sideOffset={8}
+          onCloseAutoFocus={(event) => {
+            // https://www.radix-ui.com/primitives/docs/components/dropdown-menu#content => onCloseAutoFocus
+            // Prevent the default behavior of focusing the trigger when the menu closes
+            event.preventDefault();
+          }}
+        >
           <FloatingMenu title={title}>{children}</FloatingMenu>
         </Content>
       </Portal>


### PR DESCRIPTION
In https://github.com/matrix-org/matrix-react-sdk/pull/12136 , we are building the TAC (Threads Activity Centre) with the `Menu` component. We have the current issue: when the TAC is closing, the button is the Spaces has his tooltip displayed again. (You can see the tooltip `Fils de discussion` at the bottom left)

https://github.com/element-hq/compound-web/assets/2621378/7cac0750-5581-4d2c-ae23-3642c2eaecbc

Because the focus is set on the `Menu` trigger when the `Menu` is closing. According to the https://www.radix-ui.com/primitives/docs/components/dropdown-menu#content `onCloseAutoFocus` property:

> Event handler called when focus moves to the trigger after closing. It can be prevented by calling `event.preventDefault`.

Adding `event.preventDefault()` stops the `Menu` trigger to have the focus after the `Menu` closing