### PR TITLE
Ensure that avatars use the correct font

### DIFF
--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -22,6 +22,7 @@ limitations under the License.
   font-size: min(calc(var(--cpd-avatar-size) * 0.5625), 60px);
   text-transform: uppercase;
   speak: none;
+  font-family: var(--cpd-font-family-sans);
   font-weight: bold;
   overflow: hidden;
   user-select: none;


### PR DESCRIPTION
They were inheriting the font-family value and therefore could end up displaying their initials in the browser's default font (as can be seen in Element Web, in a couple spots).