### PR TITLE
Fix the action input overflowing of small containers

### DIFF
--- a/src/components/Form/Controls/Action/Action.module.css
+++ b/src/components/Form/Controls/Action/Action.module.css
@@ -22,6 +22,12 @@ limitations under the License.
 .control {
   flex: 1;
   padding-inline-end: var(--cpd-space-12x) !important;
+
+  /* From the flexbox spec:
+   *   "By default, flex items won’t shrink below their minimum content size"
+   * This allows the element to shrink lower than its natural default size.
+   */
+  min-inline-size: 0;
 }
 
 .action {


### PR DESCRIPTION
This is one of the weirdness of flexbox. See https://dfmcphee.com/flex-items-and-min-width-0/



Before: ([Storybook](https://compound-web.pages.dev/?path=/story/form-kitchen-sink--normal)) 
![image](https://github.com/element-hq/compound-web/assets/1549952/775266e2-3231-4e3b-8e8e-72881f97c119)


After: ([Storybook](https://quenting-action-input-min-wi.compound-web.pages.dev/?path=/story/form-kitchen-sink--normal)) 
![image](https://github.com/element-hq/compound-web/assets/1549952/869076ac-f44f-40ad-baf0-5a61217b845e)