### PR TITLE
Fix release announcement for react 17

### DIFF
--- a/src/components/ReleaseAnnouncement/ReleaseAnnouncement.tsx
+++ b/src/components/ReleaseAnnouncement/ReleaseAnnouncement.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import React, {
   cloneElement,
   isValidElement,
+  JSX,
   PropsWithChildren,
   Ref,
 } from "react";
@@ -60,7 +61,7 @@ export function ReleaseAnnouncement({
   children,
   placement = "right",
   ...props
-}: PropsWithChildren<ReleaseAnnouncementProps>) {
+}: PropsWithChildren<ReleaseAnnouncementProps>): JSX.Element {
   const context = useReleaseAnnouncement({ placement, ...props });
 
   return (
@@ -79,7 +80,9 @@ export function ReleaseAnnouncement({
  * @param children - should be a single valid React element
  * @constructor
  */
-function ReleaseAnnouncementAnchor({ children }: Readonly<PropsWithChildren>) {
+function ReleaseAnnouncementAnchor({
+  children,
+}: Readonly<PropsWithChildren>): JSX.Element {
   const context = useReleaseAnnouncementContext();
 
   // The children can have a ref and we don't want to discard it
@@ -108,7 +111,9 @@ function ReleaseAnnouncementAnchor({ children }: Readonly<PropsWithChildren>) {
  * Manage focus and positioning of the children.
  * @param children
  */
-function ReleaseAnnouncementContainer({ children }: PropsWithChildren) {
+function ReleaseAnnouncementContainer({
+  children,
+}: PropsWithChildren): JSX.Element | null {
   const {
     context: floatingContext,
     arrowRef,
@@ -151,7 +156,7 @@ function ReleaseAnnouncementContainer({ children }: PropsWithChildren) {
  * - Description can be on multiple lines       -------------    -
  * ---------------------------------------------------------------
  */
-function ReleaseAnnouncementContent() {
+function ReleaseAnnouncementContent(): JSX.Element {
   const { labelId, descriptionId, header, description, closeLabel, onClick } =
     useReleaseAnnouncementContext();
 


### PR DESCRIPTION
When not specifying the `JSX`import, the build uses this import `import("react/jsx-runtime").JSX.Element`

Built version
```ts
export declare function ReleaseAnnouncement({ 
/**
 * The children anchor should be a single valid React element.
 */
children, placement, ...props }: PropsWithChildren<ReleaseAnnouncementProps>): import("react/jsx-runtime").JSX.Element;
export {};
```

But in react 17, `JSX` is not available in `import("react/jsx-runtime")`

https://github.com/matrix-org/matrix-react-sdk/actions/runs/8540097333/job/23396360882?pr=12380
`node_modules/@vector-im/compound-web/dist/components/ReleaseAnnouncement/ReleaseAnnouncement.d.ts(22,108): error TS2694: Namespace '"/home/runner/work/matrix-react-sdk/matrix-react-sdk/node_modules/@types/react/jsx-runtime"' has no exported member 'JSX'.`