### PR TITLE
Release Announcement: fix accessibility issue on the anchor

### DIFF
--- a/src/components/ReleaseAnnouncement/ReleaseAnnouncement.tsx
+++ b/src/components/ReleaseAnnouncement/ReleaseAnnouncement.tsx
@@ -101,7 +101,11 @@ function ReleaseAnnouncementAnchor({
     context.getReferenceProps({
       ref,
       ...children.props,
-      "data-state": context.open ? "open" : "closed",
+      // If the ReleaseAnnouncement is open, we need manually aria-describedby.
+      // The RA has the dialog role and it's not adding automatically the aria-describedby.
+      ...(context.open && {
+        "aria-describedby": context.getFloatingProps().id,
+      }),
     }),
   );
 }


### PR DESCRIPTION
Add `aria-describedby` manually on the anchor.
The role of the RA is a `dialog` and not a `tooltip`, so `floating-ui` doesn't add this attribute.

I also removed a useless data-attribute. It was used in the floating ui example to show that we can have access to the some internal state but there is no use case for us.