### PR TITLE
Remove useless data-state on tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -160,7 +160,6 @@ function TooltipAnchor({ children }: Readonly<PropsWithChildren>): JSX.Element {
     context.getReferenceProps({
       ref,
       ...children.props,
-      "data-state": context.open ? "open" : "closed",
     }),
   );
 }

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -47,7 +47,6 @@ exports[`Tooltip > opens tooltip on focus where trigger is non interactive 1`] =
     style="padding: 100px;"
   >
     <span
-      data-state="closed"
       tabindex="0"
     >
       <button
@@ -134,7 +133,6 @@ exports[`Tooltip > overrides default tab index for non interactive triggers 1`] 
     style="padding: 100px;"
   >
     <span
-      data-state="closed"
       tabindex="-1"
     >
       <button
@@ -179,9 +177,7 @@ exports[`Tooltip > renders closed by default 1`] = `
   <div
     style="padding: 100px;"
   >
-    <span
-      data-state="closed"
-    >
+    <span>
       No tooltip to see here
     </span>
   </div>
@@ -237,7 +233,6 @@ exports[`Tooltip > renders open by default 1`] = `
     <button
       aria-describedby=":r2:"
       class="_icon-button_e3253e"
-      data-state="open"
       data-testid="testbutton"
       role="button"
       style="--cpd-icon-button-size: 32px;"
@@ -319,7 +314,6 @@ exports[`Tooltip > renders with caption 1`] = `
   >
     <button
       class="_icon-button_e3253e"
-      data-state="closed"
       data-testid="testbutton"
       role="button"
       style="--cpd-icon-button-size: 32px;"


### PR DESCRIPTION
This data attribute was in the floating ui example to show we can have access to some data in the internal state of the component. In our case, we don't need, it's polluting the dom.