### PR TITLE
Fetch avatars without CORS

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -121,7 +121,6 @@ export const Avatar = forwardRef<
           loading="lazy"
           alt=""
           src={src}
-          crossOrigin="anonymous"
           referrerPolicy="no-referrer"
           className={classnames(styles.image)}
           data-type={type}


### PR DESCRIPTION
By omitting the `crossOrigin` attribute, we change avatars to use a non-CORS request to fetch the image. This allows avatars to load even on null origins (fixing https://github.com/element-hq/element-web/issues/26491), but also prevents us from inspecting the image data in JavaScript, for example by using it in a canvas. We weren't doing that of course, so switching to the locked-down non-CORS mode should have no consequences.

Closes https://github.com/element-hq/compound/issues/293