### PR TITLE
Revert "Memoize cloned element in tooltip"

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -27,7 +27,6 @@ import React, {
   JSX,
   isValidElement,
   cloneElement,
-  useMemo,
 } from "react";
 
 import classNames from "classnames";
@@ -164,22 +163,15 @@ function TooltipAnchor({ children }: Readonly<PropsWithChildren>): JSX.Element {
   const childrenRef = (children as unknown as { ref?: Ref<HTMLElement> })?.ref;
   const ref = useMergeRefs([context.refs.setReference, childrenRef]);
 
-  // We need to check `isValidElement` to infer the type of `children`
-  const childrenProps = isValidElement(children) && children.props;
-
-  const element = useMemo(() => {
-    if (!isValidElement(children)) return;
-
-    const props = context.getReferenceProps({
-      ref,
-      ...childrenProps,
-    });
-    return cloneElement(children, props);
-  }, [ref, children, childrenProps]);
-
-  if (!element) {
+  if (!isValidElement(children)) {
     throw new Error("Tooltip anchor must be a single valid React element");
   }
 
-  return element;
+  return cloneElement(
+    children,
+    context.getReferenceProps({
+      ref,
+      ...children.props,
+    }),
+  );
 }


### PR DESCRIPTION
Reverts element-hq/compound-web#167

It's create regression in rerender of the anchor.

We should do a deep comparison of the new computed props and use it in the memo dependencies.