### PR TITLE
replace graphemer by unicode-segmenter

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@radix-ui/react-tooltip": "^1.0.6",
     "@storybook/manager-api": "^8.1.1",
     "classnames": "^2.3.2",
-    "graphemer": "^1.4.0",
+    "unicode-segmenter": "^0.9.0",
     "vaul": "^0.7.0"
   },
   "peerDependencies": {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -14,26 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import GraphemeSplitter from "graphemer";
+import { graphemeSegments } from "unicode-segmenter/grapheme";
 
 export const MX_USERNAME_PREFIX = "@";
 export const MX_ROOM_PREFIX = "#";
 export const MX_ALIAS_PREFIX = "+";
-
-/**
- * The CommonJS output of the graphemer package looks wrong,
- * this is a workaround
- * To remove when https://github.com/flmnt/graphemer/issues/11 is fixed
- * @param value the constructor or wrapper with `default`
- * @returns the Graphemer constructor
- */
-function interopDefault<T>(value: T): T {
-  if ((value as unknown as { default: T }).default) {
-    return (value as unknown as { default: T }).default;
-  }
-
-  return value;
-}
 
 /**
  * returns the first (non-sigil) character of 'name',
@@ -52,7 +37,6 @@ export function getInitialLetter(name: string): string {
   }
 
   // rely on a grapheme cluster splitter so that we don't break apart compound emojis
-  const splitter = new (interopDefault(GraphemeSplitter))();
-  const result = splitter.iterateGraphemes(name).next();
-  return result.done ? "" : result.value;
+  const result = graphemeSegments(name).next();
+  return result.done ? "" : result.value.segment;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9562,6 +9562,11 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
 
+unicode-segmenter@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/unicode-segmenter/-/unicode-segmenter-0.9.0.tgz#4285467f2629b0b7d4fa0f16df87c76064af1536"
+  integrity sha512-Y1TfI9jUxhEF6j0rKDLoNSou38jR5dd79xe8H9I12jiMm03Wwjrrk4u70u8NQz9CeamROcAQG8KEQaFhJPwBPA==
+
 unicorn-magic@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"


### PR DESCRIPTION
I made a Unicode library that is much smaller and faster than graphemer. Check it out: https://github.com/cometkim/unicode-segmenter?tab=readme-ov-file#unicode-segmentergrapheme-vs

- 2x smaller
- 6~9x faster
- ESM/CJS support
- Latest Unicode data

It ensures compliance with the latest Unicode data by performing tests and fuzzing against the `Intl.Segmenter` API.