### PR TITLE
Fix dev dependencies and bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@storybook/addon-interactions": "^8.1.1",
     "@storybook/addon-links": "^8.1.1",
     "@storybook/addon-themes": "^8.1.1",
+    "@storybook/manager-api": "^8.1.1",
     "@storybook/react": "^8.1.1",
     "@storybook/react-vite": "^8.1.1",
     "@storybook/test": "^8.1.1",
@@ -109,7 +110,6 @@
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.0.6",
-    "@storybook/manager-api": "^8.1.1",
     "classnames": "^2.3.2",
     "vaul": "^0.7.0"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,9 +33,13 @@ export default defineConfig({
         "react/jsx-dev-runtime",
         "classnames",
         "vaul",
+        "@floating-ui/react",
+        "@floating-ui/react-dom",
         "@radix-ui/react-context-menu",
         "@radix-ui/react-dropdown-menu",
         "@radix-ui/react-form",
+        "@radix-ui/react-separator",
+        "@radix-ui/react-slot",
         "@radix-ui/react-tooltip",
       ],
 


### PR DESCRIPTION
I wondered why updating compound exploded the number of dependencies in my lockfile, and this is why.

It also looks like new dependencies got added but not marked as external, so they ended up in the bundle.
