### PR TITLE
Set a default background color in storybook docs pages

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,0 +1,3 @@
+.docs-story {
+  background: var(--cpd-color-bg-canvas-default);
+}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -8,6 +8,7 @@ import "@fontsource/inter/600.css";
 import "@fontsource/inter/700.css";
 import "@vector-im/compound-design-tokens/assets/web/css/compound-design-tokens.css";
 import "../src/styles/global.css";
+import "./preview.css";
 
 export const parameters: Parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },


### PR DESCRIPTION
This is to help review stories with the dark variant. It's only affecting the generated docs pages, not the individual stories

| Before | After |
| --- | --- |
| ![image](https://github.com/element-hq/compound-web/assets/1549952/993942cd-b6da-4c5f-a2d0-c82ebc6d9f99) | ![image](https://github.com/element-hq/compound-web/assets/1549952/a5244524-854a-46d3-8ad2-dac6336d5df6) |