### PR TITLE
EditInPlace: pass error messages as children to allow better messages

### DIFF
--- a/src/components/Form/Controls/EditInPlace/EditInPlace.stories.tsx
+++ b/src/components/Form/Controls/EditInPlace/EditInPlace.stories.tsx
@@ -19,6 +19,7 @@ import React from "react";
 import { EditInPlace } from "./";
 import { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, within } from "@storybook/test";
+import { ErrorMessage } from "../../Message";
 
 type Props = { invalid?: boolean } & React.ComponentProps<typeof EditInPlace>;
 
@@ -32,11 +33,14 @@ export default {
         "onChange",
         "onSave",
         "onCancel",
+        "onClearServerErrors",
         "defaultValue",
         "error",
+        "serverInvalid",
         "savedLabel",
         "saveButtonLabel",
         "cancelButtonLabel",
+        "helpLabel",
         "disabled",
       ],
     },
@@ -58,7 +62,13 @@ export default {
     onCancel: {
       action: "cancelled",
     },
-    error: {
+    onClearServerErrors: {
+      action: "cleared server errors",
+    },
+    serverInvalid: {
+      type: "boolean",
+    },
+    helpLabel: {
       type: "string",
     },
     savedLabel: {
@@ -122,7 +132,8 @@ export const Saving: Story = {
 
 export const WithError: Story = {
   args: {
-    error: "I am a teapot",
+    serverInvalid: true,
+    children: <ErrorMessage>I am a teapot</ErrorMessage>,
   },
 };
 

--- a/src/components/Form/Controls/EditInPlace/EditInPlace.test.tsx
+++ b/src/components/Form/Controls/EditInPlace/EditInPlace.test.tsx
@@ -22,31 +22,27 @@ import { userEvent } from "@storybook/test";
 import { act } from "react-dom/test-utils";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { EditInPlace } from "./EditInPlace";
+import { ErrorMessage } from "../../Message";
 
-type EditInPlaceTestProps = {
-  error?: string;
-  defaultValue?: string;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onSave?: () => Promise<void>;
-  onCancel?: () => void;
-  disabled?: boolean;
-};
+type EditInPlaceTestProps = Omit<
+  React.ComponentProps<typeof EditInPlace>,
+  | "saveButtonLabel"
+  | "cancelButtonLabel"
+  | "savedLabel"
+  | "savingLabel"
+  | "label"
+>;
 
 describe("EditInPlace", () => {
   const EditInPlaceTest = (props: EditInPlaceTestProps) => (
     <TooltipProvider>
       <EditInPlace
         label="Edit Me"
-        defaultValue={props.defaultValue}
-        error={props.error}
-        onChange={props.onChange ?? (() => {})}
-        onSave={props.onSave ?? (() => Promise.resolve())}
-        onCancel={props.onCancel ?? (() => {})}
         saveButtonLabel="Save"
         cancelButtonLabel="Cancel"
         savedLabel="Saved"
         savingLabel="Saving..."
-        disabled={props.disabled}
+        {...props}
       />
     </TooltipProvider>
   );
@@ -88,9 +84,11 @@ describe("EditInPlace", () => {
     expect(input).toBeValid();
   });
 
-  it("renders error icon and text if error provided", () => {
+  it("renders error icon and text if passed as children", () => {
     const { asFragment, getByRole, getByText } = render(
-      <EditInPlaceTest error="Missing Left Falangey" />,
+      <EditInPlaceTest serverInvalid>
+        <ErrorMessage>Missing Left Falangey</ErrorMessage>
+      </EditInPlaceTest>,
     );
     expect(asFragment()).toMatchSnapshot();
 
@@ -102,6 +100,88 @@ describe("EditInPlace", () => {
     expect(errorText).toBeInTheDocument();
 
     expect(errorText.id).toEqual(input.getAttribute("aria-describedby"));
+  });
+
+  it("uses native form validation logic", async () => {
+    const { asFragment, getByRole, queryByText } = render(
+      <EditInPlaceTest type="email" required>
+        <ErrorMessage match="valueMissing">you did not fill this</ErrorMessage>
+        <ErrorMessage match="typeMismatch">this is not an email</ErrorMessage>
+      </EditInPlaceTest>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+
+    const input = getByRole("textbox");
+    expect(input).toBeInvalid();
+
+    // The message hasn't showed up yet
+    expect(queryByText("you did not fill this")).not.toBeInTheDocument();
+
+    await act(async () => {
+      // Focus and submit the form
+      await userEvent.keyboard("{tab}{enter}");
+    });
+
+    // The message should be there
+    expect(queryByText("you did not fill this")).toBeInTheDocument();
+
+    await act(async () => {
+      // Type an invalid email
+      await userEvent.type(input, "notanemail");
+      await userEvent.keyboard("{enter}");
+    });
+
+    // Another message should be there
+    expect(queryByText("you did not fill this")).not.toBeInTheDocument();
+    expect(queryByText("this is not an email")).toBeInTheDocument();
+
+    await act(async () => {
+      // Type something else to clear out the errors
+      await userEvent.clear(input);
+      await userEvent.type(input, "something else");
+    });
+
+    // The message should be gone
+    expect(queryByText("you did not fill this")).not.toBeInTheDocument();
+    expect(queryByText("this is not an email")).not.toBeInTheDocument();
+  });
+
+  it("uses the custom error messages passed as children", async () => {
+    const { getByRole, queryByText, asFragment } = render(
+      <EditInPlaceTest>
+        <ErrorMessage match={(value) => value !== "hunter2"}>
+          password should be hunter2
+        </ErrorMessage>
+      </EditInPlaceTest>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+
+    const input = getByRole("textbox");
+
+    // The message hasn't showed up yet
+    expect(queryByText("password should be hunter2")).not.toBeInTheDocument();
+    expect(input).toBeValid();
+
+    await act(async () => {
+      // Focus, type and submit the form
+      await userEvent.type(input, "something");
+      await userEvent.keyboard("{tab}");
+    });
+
+    // The message should be there
+    expect(queryByText("password should be hunter2")).toBeInTheDocument();
+    expect(input).toBeInvalid();
+
+    await act(async () => {
+      // Type the correct password
+      await userEvent.clear(input);
+      await userEvent.type(input, "hunter2");
+      await userEvent.keyboard("{tab}");
+    });
+
+    // The message should be gone and the input valid
+    expect(queryByText("password should be hunter2")).not.toBeInTheDocument();
+    expect(input).toBeValid();
   });
 
   it("should show the buttons when the input or buttons are focused", async () => {

--- a/src/components/Form/Controls/EditInPlace/__snapshots__/EditInPlace.test.tsx.snap
+++ b/src/components/Form/Controls/EditInPlace/__snapshots__/EditInPlace.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`EditInPlace > disables control when disabled 1`] = `
     >
       <label
         class="_label_dc87d2"
-        for="radix-:r3n:"
+        for="radix-:r4h:"
       >
         Edit Me
       </label>
@@ -20,10 +20,9 @@ exports[`EditInPlace > disables control when disabled 1`] = `
         <input
           class="_control_a839aa"
           disabled=""
-          id="radix-:r3n:"
+          id="radix-:r4h:"
           name="input"
           title=""
-          value=""
         />
       </div>
     </div>
@@ -41,7 +40,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 1`] = `
     >
       <label
         class="_label_dc87d2"
-        for="radix-:r34:"
+        for="radix-:r3u:"
       >
         Edit Me
       </label>
@@ -50,10 +49,9 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 1`] = `
       >
         <input
           class="_control_a839aa"
-          id="radix-:r34:"
+          id="radix-:r3u:"
           name="input"
           title=""
-          value=""
         />
       </div>
     </div>
@@ -73,7 +71,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
       <label
         class="_label_dc87d2"
         data-valid="true"
-        for="radix-:r34:"
+        for="radix-:r3u:"
       >
         Edit Me
       </label>
@@ -81,18 +79,17 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
         class="_controls_980156"
       >
         <input
-          aria-describedby="radix-:r3d:"
+          aria-describedby="radix-:r47:"
           class="_control_a839aa"
           data-valid="true"
-          id="radix-:r34:"
+          id="radix-:r3u:"
           name="input"
           title=""
-          value=""
         />
       </div>
       <span
         class="_message_dc87d2 _success-message_dc87d2"
-        id="radix-:r3d:"
+        id="radix-:r47:"
       >
         <svg
           class="cpd-icon"
@@ -135,7 +132,6 @@ exports[`EditInPlace > renders 1`] = `
           id="radix-:r0:"
           name="input"
           title=""
-          value=""
         />
       </div>
     </div>
@@ -143,7 +139,7 @@ exports[`EditInPlace > renders 1`] = `
 </DocumentFragment>
 `;
 
-exports[`EditInPlace > renders error icon and text if error provided 1`] = `
+exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
 <DocumentFragment>
   <form
     class="_root_dc87d2"
@@ -170,7 +166,6 @@ exports[`EditInPlace > renders error icon and text if error provided 1`] = `
           id="radix-:rb:"
           name="input"
           title=""
-          value=""
         />
         <div
           class="_button-group_980156"
@@ -243,6 +238,66 @@ exports[`EditInPlace > renders error icon and text if error provided 1`] = `
         </svg>
         Missing Left Falangey
       </span>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`EditInPlace > uses native form validation logic 1`] = `
+<DocumentFragment>
+  <form
+    class="_root_dc87d2"
+  >
+    <div
+      class="_field_dc87d2"
+    >
+      <label
+        class="_label_dc87d2"
+        for="radix-:rl:"
+      >
+        Edit Me
+      </label>
+      <div
+        class="_controls_980156"
+      >
+        <input
+          class="_control_a839aa"
+          id="radix-:rl:"
+          name="input"
+          required=""
+          title=""
+          type="email"
+        />
+      </div>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`EditInPlace > uses the custom error messages passed as children 1`] = `
+<DocumentFragment>
+  <form
+    class="_root_dc87d2"
+  >
+    <div
+      class="_field_dc87d2"
+    >
+      <label
+        class="_label_dc87d2"
+        for="radix-:r10:"
+      >
+        Edit Me
+      </label>
+      <div
+        class="_controls_980156"
+      >
+        <input
+          class="_control_a839aa"
+          id="radix-:r10:"
+          name="input"
+          title=""
+        />
+      </div>
     </div>
   </form>
 </DocumentFragment>

--- a/src/components/Form/Controls/EditInPlace/__snapshots__/EditInPlace.test.tsx.snap
+++ b/src/components/Form/Controls/EditInPlace/__snapshots__/EditInPlace.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`EditInPlace > disables control when disabled 1`] = `
     >
       <label
         class="_label_dc87d2"
-        for="radix-:r4h:"
+        for="radix-:r55:"
       >
         Edit Me
       </label>
@@ -20,7 +20,7 @@ exports[`EditInPlace > disables control when disabled 1`] = `
         <input
           class="_control_a839aa"
           disabled=""
-          id="radix-:r4h:"
+          id="radix-:r55:"
           name="input"
           title=""
         />
@@ -82,6 +82,113 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
           aria-describedby="radix-:r47:"
           class="_control_a839aa"
           data-valid="true"
+          disabled=""
+          id="radix-:r3u:"
+          name="input"
+          title=""
+        />
+        <div
+          class="_button-group_980156"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Save"
+            class="_button_2a1efe _has-icon_2a1efe _icon-only_2a1efe"
+            data-kind="primary"
+            data-size="sm"
+            role="button"
+            tabindex="0"
+            type="submit"
+          >
+            <svg
+              aria-hidden="true"
+              class="_icon_2a1efe"
+              fill="currentColor"
+              height="20"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9.55 17.575c-.133 0-.258-.02-.375-.063a.878.878 0 0 1-.325-.212L4.55 13c-.183-.183-.27-.42-.263-.713.009-.291.105-.529.288-.712a.948.948 0 0 1 .7-.275.95.95 0 0 1 .7.275L9.55 15.15l8.475-8.475c.183-.183.42-.275.712-.275s.53.092.713.275c.183.183.275.42.275.712s-.092.53-.275.713l-9.2 9.2c-.1.1-.208.17-.325.212a1.106 1.106 0 0 1-.375.063Z"
+              />
+            </svg>
+          </button>
+          <button
+            aria-disabled="true"
+            aria-label="Cancel"
+            class="_button_2a1efe _button_980156 _has-icon_2a1efe _icon-only_2a1efe"
+            data-kind="secondary"
+            data-size="sm"
+            role="button"
+            tabindex="0"
+            type="reset"
+          >
+            <svg
+              aria-hidden="true"
+              class="_icon_2a1efe"
+              fill="currentColor"
+              height="20"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M6.293 6.293a1 1 0 0 1 1.414 0L12 10.586l4.293-4.293a1 1 0 1 1 1.414 1.414L13.414 12l4.293 4.293a1 1 0 0 1-1.414 1.414L12 13.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L10.586 12 6.293 7.707a1 1 0 0 1 0-1.414Z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <span
+        class="_message_dc87d2"
+        id="radix-:r47:"
+      >
+        <svg
+          class="_icon_01cd2d"
+          fill="currentColor"
+          height="1em"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M12 4.031a8 8 0 1 0 8 8 1 1 0 0 1 2 0c0 5.523-4.477 10-10 10s-10-4.477-10-10 4.477-10 10-10a1 1 0 1 1 0 2Z"
+            fill-rule="evenodd"
+          />
+        </svg>
+        Saving...
+      </span>
+    </div>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`EditInPlace > displays saved label for 2 seconds after save 3`] = `
+<DocumentFragment>
+  <form
+    class="_root_dc87d2"
+  >
+    <div
+      class="_field_dc87d2"
+      data-valid="true"
+    >
+      <label
+        class="_label_dc87d2"
+        data-valid="true"
+        for="radix-:r3u:"
+      >
+        Edit Me
+      </label>
+      <div
+        class="_controls_980156"
+      >
+        <input
+          aria-describedby="radix-:r48:"
+          class="_control_a839aa"
+          data-valid="true"
           id="radix-:r3u:"
           name="input"
           title=""
@@ -89,7 +196,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
       </div>
       <span
         class="_message_dc87d2 _success-message_dc87d2"
-        id="radix-:r47:"
+        id="radix-:r48:"
       >
         <svg
           class="cpd-icon"


### PR DESCRIPTION
Radix forms is supposed to leverage native validation APIs.
This means that setting `required`, `type=email`, `minlength` on the input field should just work.
It already worked, but there was no way to set an error message.

This is because you're supposed to have `<Message match="...">` inside the field, to render the error message for each kind of error you'd expect.

This makes it so that `children` passed in the `<EditInPlace>` component are rendered within the `<Field>`, which lets us do something like:

```jsx
<EditInPlace type="email" required minLength={5} maxLength={100}>
    <ErrorMessage match="valueMissing">This field is required</ErrorMessage>
    <ErrorMessage match="typeMismatch">This field must be an email</ErrorMessage>
    <ErrorMessage match="tooShort">This field must be at least 5 characters long</ErrorMessage>
    <ErrorMessage match="tooLong">This field must be at most 100 characters long</ErrorMessage>
    {/* and for custom errors: */}
    <ErrorMessage match={e => e.endsWith("@matrix.org")}>The email must end with @matrix.org</ErrorMessage>
</EditInPlace>
```

This means we ditch the `error` prop, in favor of the `children` and the `serverInvalid` prop, if you need to report errors from the server.

```jsx
<EditInPlace serverInvalid={Boolean(error)}>
    {error && <ErrorMessage>{error}</ErrorMessage>}
</EditInPlace>
```

I can keep the (deprecated) `error` prop if we want to avoid making a breaking change
