### PR TITLE
Allow setting a ref on InlineSpinner

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/react": "^18.2.21",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
-    "@vector-im/compound-design-tokens": "^1.6.0",
+    "@vector-im/compound-design-tokens": "^1.6.1",
     "@vitejs/plugin-react": "^4.0.4",
     "@vitest/coverage-v8": "^0.34.4",
     "browserslist-to-esbuild": "^1.2.0",
@@ -117,7 +117,7 @@
     "@fontsource/inconsolata": "^5",
     "@fontsource/inter": "^5",
     "@types/react": "*",
-    "@vector-im/compound-design-tokens": ">=1.6.0 <2.0.0",
+    "@vector-im/compound-design-tokens": ">=1.6.1 <2.0.0",
     "react": "^17 || ^18"
   },
   "peerDependenciesMeta": {

--- a/src/components/InlineSpinner/InlineSpinner.tsx
+++ b/src/components/InlineSpinner/InlineSpinner.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { SVGAttributes } from "react";
+import React, { SVGAttributes, forwardRef } from "react";
 import styles from "./InlineSpinner.module.css";
 import SpinnerIcon from "@vector-im/compound-design-tokens/assets/web/icons/spinner";
 
@@ -22,12 +22,15 @@ type InlineSpinnerProps = {
   size?: number;
 } & SVGAttributes<SVGElement>;
 
-export function InlineSpinner({ size = 20, ...props }: InlineSpinnerProps) {
-  return (
-    <SpinnerIcon
-      className={styles.icon}
-      style={{ width: size, height: size }}
-      {...props}
-    />
-  );
-}
+export const InlineSpinner = forwardRef<SVGSVGElement, InlineSpinnerProps>(
+  function InlineSpinner({ size = 20, ...props }, ref) {
+    return (
+      <SpinnerIcon
+        ref={ref}
+        className={styles.icon}
+        style={{ width: size, height: size }}
+        {...props}
+      />
+    );
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3573,10 +3573,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vector-im/compound-design-tokens@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@vector-im/compound-design-tokens/-/compound-design-tokens-1.6.0.tgz#75e5059d3d87930a5fb5a31c6921ec10724c53da"
-  integrity sha512-67o1tF5ygp6axRbaaoUVAtgYS591BUV27d92L4dtexRvVvkRyGvdAk44MMWuyhHT/SYb6WFw5zxJbVDeS5WFPQ==
+"@vector-im/compound-design-tokens@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vector-im/compound-design-tokens/-/compound-design-tokens-1.6.1.tgz#3f1bb5b2b9f8aff10144aab19dfa11165c3c927b"
+  integrity sha512-u5xG/8AN7QkPPWhugj0ZrQtWsAjuKHzuOoP0s3bbDg7ZkKTE9l5tM29bdOHnSv9mEYKO+KVMMfsl0W1rlaTmAw==
 
 "@vitejs/plugin-react@^4.0.4":
   version "4.1.0"


### PR DESCRIPTION
We can do this now that we're consuming the custom SVG components exported by the design tokens package.

Closes https://github.com/element-hq/compound-web/issues/192