### PR TITLE
Update the minimum peer dependency for design tokens to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@fontsource/inconsolata": "^5",
     "@fontsource/inter": "^5",
     "@types/react": "*",
-    "@vector-im/compound-design-tokens": ">=1.0.0 <2.0.0",
+    "@vector-im/compound-design-tokens": ">=1.6.0 <2.0.0",
     "react": "^17 || ^18"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
If consumers forget to update the design tokens, it will break stuff for them.
This makes sure consumers have recent enough design tokens.
