### PR TITLE
Bring back the tooltip warm-up period

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "@radix-ui/react-progress": "^1.0.3",
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
-    "@radix-ui/react-tooltip": "^1.0.6",
     "classnames": "^2.3.2",
     "ts-xor": "^1.3.0",
     "vaul": "^0.7.0"

--- a/src/components/Button/ActionButton.stories.tsx
+++ b/src/components/Button/ActionButton.stories.tsx
@@ -21,14 +21,17 @@ import { fn } from "@storybook/test";
 import * as icons from "@vector-im/compound-design-tokens/assets/web/icons";
 
 import { Button as ButtonComponent } from "./Button";
-import { Tooltip } from "../..";
+import { Tooltip } from "../Tooltip/Tooltip";
+import { TooltipProvider } from "../Tooltip/TooltipProvider";
 
 const Template: React.FC<
   { label: string } & React.ComponentProps<typeof ButtonComponent>
 > = ({ label, ...args }) => (
-  <Tooltip label={label}>
-    <ButtonComponent iconOnly {...args} />
-  </Tooltip>
+  <TooltipProvider>
+    <Tooltip label={label}>
+      <ButtonComponent iconOnly {...args} />
+    </Tooltip>
+  </TooltipProvider>
 );
 
 export default {

--- a/src/components/Form/Controls/Action/Action.stories.tsx
+++ b/src/components/Form/Controls/Action/Action.stories.tsx
@@ -22,6 +22,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import * as icons from "@vector-im/compound-design-tokens/assets/web/icons";
 
 import { ActionInput } from "./";
+import { TooltipProvider } from "../../../Tooltip/TooltipProvider";
 
 type Props = { invalid?: boolean } & React.ComponentProps<typeof ActionInput>;
 
@@ -79,7 +80,9 @@ export default {
     },
   },
   render: ({ invalid, ...restArgs }) => (
-    <ActionInput data-invalid={invalid || undefined} {...restArgs} />
+    <TooltipProvider>
+      <ActionInput data-invalid={invalid || undefined} {...restArgs} />
+    </TooltipProvider>
   ),
   args: {
     placeholder: "",

--- a/src/components/Form/Controls/Action/Action.test.tsx
+++ b/src/components/Form/Controls/Action/Action.test.tsx
@@ -20,18 +20,21 @@ import React from "react";
 import ChatIcon from "@vector-im/compound-design-tokens/assets/web/icons/chat";
 
 import { ActionInput } from "./Action";
+import { TooltipProvider } from "../../../Tooltip/TooltipProvider";
 import userEvent from "@testing-library/user-event";
 
 describe("ActionInput", () => {
   it("renders", () => {
     const { asFragment } = render(
-      <ActionInput
-        Icon={ChatIcon}
-        actionLabel="Click me!"
-        onActionClick={() => {
-          console.log("clicked!");
-        }}
-      />,
+      <TooltipProvider>
+        <ActionInput
+          Icon={ChatIcon}
+          actionLabel="Click me!"
+          onActionClick={() => {
+            console.log("clicked!");
+          }}
+        />
+      </TooltipProvider>,
     );
     expect(asFragment()).toMatchSnapshot();
   });
@@ -41,11 +44,13 @@ describe("ActionInput", () => {
     const spy = vi.fn();
 
     render(
-      <ActionInput
-        Icon={ChatIcon}
-        actionLabel="Click me!"
-        onActionClick={spy}
-      />,
+      <TooltipProvider>
+        <ActionInput
+          Icon={ChatIcon}
+          actionLabel="Click me!"
+          onActionClick={spy}
+        />
+      </TooltipProvider>,
     );
 
     await user.click(screen.getByRole("button", { name: "Click me!" }));

--- a/src/components/Form/Controls/EditInPlace/EditInPlace.stories.tsx
+++ b/src/components/Form/Controls/EditInPlace/EditInPlace.stories.tsx
@@ -20,6 +20,7 @@ import { EditInPlace } from "./";
 import { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, within } from "@storybook/test";
 import { ErrorMessage } from "../../Message";
+import { TooltipProvider } from "../../../Tooltip/TooltipProvider";
 
 type Props = { invalid?: boolean } & React.ComponentProps<typeof EditInPlace>;
 
@@ -87,7 +88,11 @@ export default {
       type: "boolean",
     },
   },
-  render: ({ ...restArgs }) => <EditInPlace {...restArgs} />,
+  render: ({ ...restArgs }) => (
+    <TooltipProvider>
+      <EditInPlace {...restArgs} />
+    </TooltipProvider>
+  ),
   args: {
     label: "Label",
     onSave: () => new Promise((resolve) => setTimeout(resolve, 1000)),

--- a/src/components/Form/Controls/EditInPlace/EditInPlace.test.tsx
+++ b/src/components/Form/Controls/EditInPlace/EditInPlace.test.tsx
@@ -23,9 +23,9 @@ import {
   waitForElementToBeRemoved,
 } from "@testing-library/react";
 
-import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { EditInPlace } from "./EditInPlace";
 import { ErrorMessage } from "../../Message";
+import { TooltipProvider } from "../../../Tooltip/TooltipProvider";
 import userEvent from "@testing-library/user-event";
 
 type EditInPlaceTestProps = Omit<

--- a/src/components/Form/Controls/Password/Password.stories.tsx
+++ b/src/components/Form/Controls/Password/Password.stories.tsx
@@ -20,6 +20,7 @@ import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import { PasswordInput } from "./";
+import { TooltipProvider } from "../../../Tooltip/TooltipProvider";
 import { screen } from "@storybook/test";
 import { userEvent } from "@storybook/test";
 
@@ -62,7 +63,9 @@ export default {
     },
   },
   render: ({ invalid, ...restArgs }) => (
-    <PasswordInput data-invalid={invalid || undefined} {...restArgs} />
+    <TooltipProvider>
+      <PasswordInput data-invalid={invalid || undefined} {...restArgs} />
+    </TooltipProvider>
   ),
   args: {
     placeholder: "",

--- a/src/components/Form/Controls/Password/Password.test.tsx
+++ b/src/components/Form/Controls/Password/Password.test.tsx
@@ -20,11 +20,16 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { PasswordInput } from "./Password";
+import { TooltipProvider } from "../../../Tooltip/TooltipProvider";
 
 describe("PasswordControl", () => {
   it("switches the input type", async () => {
     const user = userEvent.setup();
-    const { container } = render(<PasswordInput defaultValue="p4ssw0rd!" />);
+    const { container } = render(
+      <TooltipProvider>
+        <PasswordInput defaultValue="p4ssw0rd!" />
+      </TooltipProvider>,
+    );
 
     expect(container.querySelector("[type=password]")).toBeInTheDocument();
     expect(container).toMatchSnapshot("invisible");

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -19,6 +19,7 @@ import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import * as Form from "./index";
+import { TooltipProvider } from "../Tooltip/TooltipProvider";
 
 type Props = {
   disabled: boolean;
@@ -27,127 +28,129 @@ type Props = {
 };
 
 const KitchenSink = ({ disabled, invalid, readOnly }: Props) => (
-  <Form.Root>
-    <Form.Field serverInvalid={invalid} name="mxid">
-      <Form.Label>Username</Form.Label>
-      <Form.TextControl
-        disabled={disabled}
-        readOnly={readOnly}
-        defaultValue="Hello world!"
-      />
-      {invalid ? (
-        <Form.ErrorMessage>Error message.</Form.ErrorMessage>
-      ) : (
-        <Form.HelpMessage>Help message.</Form.HelpMessage>
-      )}
-    </Form.Field>
-
-    <Form.Field serverInvalid={invalid} name="password">
-      <Form.Label>Password</Form.Label>
-      <Form.PasswordControl
-        disabled={disabled}
-        readOnly={readOnly}
-        defaultValue="sup3rS3cur3p4ssw0rd!"
-      />
-      {invalid ? (
-        <Form.ErrorMessage>Error message.</Form.ErrorMessage>
-      ) : (
-        <Form.HelpMessage>Help message.</Form.HelpMessage>
-      )}
-    </Form.Field>
-
-    <Form.Field serverInvalid={invalid} name="mfa">
-      <Form.Label>MFA</Form.Label>
-      <Form.MFAControl
-        disabled={disabled}
-        readOnly={readOnly}
-        defaultValue="123"
-      />
-      {invalid ? (
-        <Form.ErrorMessage>Error message.</Form.ErrorMessage>
-      ) : (
-        <Form.HelpMessage>Help message.</Form.HelpMessage>
-      )}
-    </Form.Field>
-
-    <Form.InlineField
-      serverInvalid={invalid}
-      name="remember"
-      control={
-        <Form.CheckboxControl
+  <TooltipProvider>
+    <Form.Root>
+      <Form.Field serverInvalid={invalid} name="mxid">
+        <Form.Label>Username</Form.Label>
+        <Form.TextControl
           disabled={disabled}
           readOnly={readOnly}
-          defaultChecked={true}
+          defaultValue="Hello world!"
         />
-      }
-    >
-      <Form.Label>Remember me</Form.Label>
-      {invalid ? (
-        <Form.ErrorMessage>Error message.</Form.ErrorMessage>
-      ) : (
-        <Form.HelpMessage>Help message.</Form.HelpMessage>
-      )}
-    </Form.InlineField>
+        {invalid ? (
+          <Form.ErrorMessage>Error message.</Form.ErrorMessage>
+        ) : (
+          <Form.HelpMessage>Help message.</Form.HelpMessage>
+        )}
+      </Form.Field>
 
-    <Form.InlineField
-      serverInvalid={invalid}
-      name="radio"
-      control={
-        <Form.RadioControl
+      <Form.Field serverInvalid={invalid} name="password">
+        <Form.Label>Password</Form.Label>
+        <Form.PasswordControl
           disabled={disabled}
           readOnly={readOnly}
-          defaultChecked={true}
+          defaultValue="sup3rS3cur3p4ssw0rd!"
         />
-      }
-    >
-      <Form.Label>Option 1</Form.Label>
-      {invalid ? (
-        <Form.ErrorMessage>Error message.</Form.ErrorMessage>
-      ) : (
-        <Form.HelpMessage>Help message.</Form.HelpMessage>
-      )}
-    </Form.InlineField>
+        {invalid ? (
+          <Form.ErrorMessage>Error message.</Form.ErrorMessage>
+        ) : (
+          <Form.HelpMessage>Help message.</Form.HelpMessage>
+        )}
+      </Form.Field>
 
-    <Form.InlineField
-      serverInvalid={invalid}
-      name="radio"
-      control={
-        <Form.RadioControl
+      <Form.Field serverInvalid={invalid} name="mfa">
+        <Form.Label>MFA</Form.Label>
+        <Form.MFAControl
           disabled={disabled}
           readOnly={readOnly}
-          defaultChecked={true}
+          defaultValue="123"
         />
-      }
-    >
-      <Form.Label>Option 2</Form.Label>
-      {invalid ? (
-        <Form.ErrorMessage>Error message.</Form.ErrorMessage>
-      ) : (
-        <Form.HelpMessage>Help message.</Form.HelpMessage>
-      )}
-    </Form.InlineField>
+        {invalid ? (
+          <Form.ErrorMessage>Error message.</Form.ErrorMessage>
+        ) : (
+          <Form.HelpMessage>Help message.</Form.HelpMessage>
+        )}
+      </Form.Field>
 
-    <Form.InlineField
-      serverInvalid={invalid}
-      name="toggle"
-      control={
-        <Form.ToggleControl
-          disabled={disabled}
-          readOnly={readOnly}
-          defaultChecked={true}
-        />
-      }
-    >
-      <Form.Label>Toggle</Form.Label>
-      {invalid ? (
-        <Form.ErrorMessage>Error message.</Form.ErrorMessage>
-      ) : (
-        <Form.HelpMessage>Help message.</Form.HelpMessage>
-      )}
-    </Form.InlineField>
+      <Form.InlineField
+        serverInvalid={invalid}
+        name="remember"
+        control={
+          <Form.CheckboxControl
+            disabled={disabled}
+            readOnly={readOnly}
+            defaultChecked={true}
+          />
+        }
+      >
+        <Form.Label>Remember me</Form.Label>
+        {invalid ? (
+          <Form.ErrorMessage>Error message.</Form.ErrorMessage>
+        ) : (
+          <Form.HelpMessage>Help message.</Form.HelpMessage>
+        )}
+      </Form.InlineField>
 
-    <Form.Submit disabled={disabled}>Submit</Form.Submit>
-  </Form.Root>
+      <Form.InlineField
+        serverInvalid={invalid}
+        name="radio"
+        control={
+          <Form.RadioControl
+            disabled={disabled}
+            readOnly={readOnly}
+            defaultChecked={true}
+          />
+        }
+      >
+        <Form.Label>Option 1</Form.Label>
+        {invalid ? (
+          <Form.ErrorMessage>Error message.</Form.ErrorMessage>
+        ) : (
+          <Form.HelpMessage>Help message.</Form.HelpMessage>
+        )}
+      </Form.InlineField>
+
+      <Form.InlineField
+        serverInvalid={invalid}
+        name="radio"
+        control={
+          <Form.RadioControl
+            disabled={disabled}
+            readOnly={readOnly}
+            defaultChecked={true}
+          />
+        }
+      >
+        <Form.Label>Option 2</Form.Label>
+        {invalid ? (
+          <Form.ErrorMessage>Error message.</Form.ErrorMessage>
+        ) : (
+          <Form.HelpMessage>Help message.</Form.HelpMessage>
+        )}
+      </Form.InlineField>
+
+      <Form.InlineField
+        serverInvalid={invalid}
+        name="toggle"
+        control={
+          <Form.ToggleControl
+            disabled={disabled}
+            readOnly={readOnly}
+            defaultChecked={true}
+          />
+        }
+      >
+        <Form.Label>Toggle</Form.Label>
+        {invalid ? (
+          <Form.ErrorMessage>Error message.</Form.ErrorMessage>
+        ) : (
+          <Form.HelpMessage>Help message.</Form.HelpMessage>
+        )}
+      </Form.InlineField>
+
+      <Form.Submit disabled={disabled}>Submit</Form.Submit>
+    </Form.Root>
+  </TooltipProvider>
 );
 
 export default {

--- a/src/components/Form/PasswordForm.stories.tsx
+++ b/src/components/Form/PasswordForm.stories.tsx
@@ -27,6 +27,7 @@ import {
   SuccessMessage,
 } from "./";
 import { Progress } from "../Progress/Progress";
+import { TooltipProvider } from "../Tooltip/TooltipProvider";
 
 export default {
   title: "Form/Password form",
@@ -35,9 +36,11 @@ export default {
   subcomponents: { Progress, PasswordControl, Label, Field },
   decorators: [
     (Story: StoryFn) => (
-      <div style={{ maxWidth: "378px" }}>
-        <Story />
-      </div>
+      <TooltipProvider>
+        <div style={{ maxWidth: "378px" }}>
+          <Story />
+        </div>
+      </TooltipProvider>
     ),
   ],
 } as Meta<typeof Root>;

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -20,6 +20,7 @@ import { IconButton } from "../Button";
 import UserIcon from "@vector-im/compound-design-tokens/assets/web/icons/user-profile";
 import { Meta, StoryFn } from "@storybook/react";
 import React, { FC, ReactNode } from "react";
+import { TooltipProvider } from "./TooltipProvider";
 
 export default {
   title: "Tooltip",
@@ -61,7 +62,9 @@ export default {
   decorators: [
     (Story: StoryFn) => (
       <div style={{ padding: 100 }}>
-        <Story />
+        <TooltipProvider>
+          <Story />
+        </TooltipProvider>
       </div>
     ),
   ],

--- a/src/components/Tooltip/TooltipProvider.tsx
+++ b/src/components/Tooltip/TooltipProvider.tsx
@@ -1,0 +1,20 @@
+import { FloatingDelayGroup } from "@floating-ui/react";
+import React, { FC } from "react";
+
+export const hoverDelay = { open: 300, close: 0 };
+
+interface Props {
+  children: JSX.Element;
+}
+
+/**
+ * Enables tooltips to share a global "warm-up" period for their hover delay.
+ * You must wrap your application in this component for tooltips to function.
+ */
+export const TooltipProvider: FC<Props> = ({ children }) => (
+  <FloatingDelayGroup delay={hoverDelay} timeoutMs={300}>
+    {children}
+  </FloatingDelayGroup>
+);
+
+TooltipProvider.displayName = "TooltipProvider";

--- a/src/components/Tooltip/useTooltip.ts
+++ b/src/components/Tooltip/useTooltip.ts
@@ -24,6 +24,7 @@ import {
   OpenChangeReason,
   Placement,
   shift,
+  useDelayGroup,
   useDismiss,
   useFloating,
   useFocus,
@@ -33,6 +34,7 @@ import {
   useRole,
 } from "@floating-ui/react";
 import { useMemo, useRef, useState, JSX } from "react";
+import { hoverDelay } from "./TooltipProvider";
 
 export interface CommonUseTooltipProps {
   /**
@@ -149,11 +151,17 @@ export function useTooltip({
   });
 
   const context = data.context;
+  const { delay, initialDelay } = useDelayGroup(context);
+  // We can tell if no delay group has been provided, because the delay will
+  // default to zero
+  if (initialDelay !== hoverDelay)
+    throw new Error("Tooltips must be wrapped in a global <TooltipProvider>");
+
   const hover = useHover(context, {
     move: false,
     enabled: controlledOpen === undefined,
     // Show tooltip after a delay when trigger is interactive
-    delay: { open: isTriggerInteractive ? 300 : 0 },
+    delay: isTriggerInteractive ? delay : {},
   });
   const focus = useFocus(context, {
     enabled: controlledOpen === undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export { Search } from "./components/Search/Search";
 export { Separator } from "./components/Separator/Separator";
 export { ToggleMenuItem } from "./components/Menu/ToggleMenuItem";
 export { Tooltip } from "./components/Tooltip/Tooltip";
+export { TooltipProvider } from "./components/Tooltip/TooltipProvider";
 export { ReleaseAnnouncement } from "./components/ReleaseAnnouncement";
 export { Toast } from "./components/Toast/Toast";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1779,24 +1779,6 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
 
-"@radix-ui/react-tooltip@^1.0.6":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.1.2.tgz#c42db2ffd7dcc6ff3d65407c8cb70490288f518d"
-  integrity sha512-9XRsLwe6Yb9B/tlnYCPVUd/TFS4J7HuOZW345DCeC6vKIxQGMZdx21RK4VoZauPD5frgkXTYVS5y90L+3YBn4w==
-  dependencies:
-    "@radix-ui/primitive" "1.1.0"
-    "@radix-ui/react-compose-refs" "1.1.0"
-    "@radix-ui/react-context" "1.1.0"
-    "@radix-ui/react-dismissable-layer" "1.1.0"
-    "@radix-ui/react-id" "1.1.0"
-    "@radix-ui/react-popper" "1.2.0"
-    "@radix-ui/react-portal" "1.1.1"
-    "@radix-ui/react-presence" "1.1.0"
-    "@radix-ui/react-primitive" "2.0.0"
-    "@radix-ui/react-slot" "1.1.0"
-    "@radix-ui/react-use-controllable-state" "1.1.0"
-    "@radix-ui/react-visually-hidden" "1.1.0"
-
 "@radix-ui/react-use-callback-ref@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz#f4bb1f27f2023c984e6534317ebc411fc181107a"
@@ -1864,13 +1846,6 @@
   integrity sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.0"
-
-"@radix-ui/react-visually-hidden@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.0.tgz#ad47a8572580f7034b3807c8e6740cd41038a5a2"
-  integrity sha512-N8MDZqtgCgG5S3aV60INAB475osJousYpZ4cTJ2cFbMpdHS5Y6loLTH8LPtkj2QN0x93J30HT/M3qJXM0+lyeQ==
-  dependencies:
-    "@radix-ui/react-primitive" "2.0.0"
 
 "@radix-ui/rect@1.1.0":
   version "1.1.0"


### PR DESCRIPTION
To make it easier to browse through tooltips on neighboring elements, a common UX optimization is to allow the hover delay to be "warmed up", so that it goes to zero after the first hover. We used to have this before the tooltip component was rewritten.

[Screencast from 2024-08-02 12-41-01.webm](https://github.com/user-attachments/assets/17179250-7208-4811-8bd5-a812f3cac336)

This is a breaking change because consumers are now required to wrap their application in a \<TooltipProvider\> component once again. I thought it'd be nice to do this before the next release because https://github.com/element-hq/compound-web/pull/229 and https://github.com/element-hq/compound-web/pull/211 are already breaking.