### PR TITLE
Allow tooltips to label non-interactive triggers

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -177,7 +177,7 @@ export const NonInteractiveTrigger = {
   args: {
     isTriggerInteractive: false,
     description: "Shown without delay",
-    children: "Just some text",
+    children: <span>Just some text</span>,
   },
 };
 

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -21,6 +21,9 @@ import React from "react";
 import * as stories from "./Tooltip.stories";
 import { composeStories, composeStory } from "@storybook/react";
 import userEvent from "@testing-library/user-event";
+import { TooltipProvider } from "./TooltipProvider";
+import { Tooltip } from "./Tooltip";
+import { UserIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
 
 const {
   Default,
@@ -79,7 +82,7 @@ describe("Tooltip", () => {
     expect(screen.queryByRole("tooltip")).toBe(null);
     await user.tab();
     // trigger focused, tooltip shown
-    expect(screen.getByText("Just some text")).toHaveFocus();
+    expect(screen.getByText("Just some text").parentElement).toHaveFocus();
     screen.getByRole("tooltip");
   });
 
@@ -124,5 +127,16 @@ describe("Tooltip", () => {
     // tooltip shown, but does not change the button's accessible name
     screen.getByRole("tooltip", { name: "Employer Identification Number" });
     expect(screen.queryByRole("button", { name: "EIN" })).toBe(null);
+  });
+
+  it("labels an image", async () => {
+    render(
+      <TooltipProvider>
+        <Tooltip isTriggerInteractive={false} label="User profile">
+          <UserIcon role="image" width={24} height={24} />
+        </Tooltip>
+      </TooltipProvider>,
+    );
+    screen.getByRole("image", { name: "User profile" });
   });
 });


### PR DESCRIPTION
The combination of tooltip labels and non-interactive triggers was problematic: The tooltip component would place the label on the span element that it creates, rather than your provided trigger element. If your trigger was an icon or image, then accessibility tooling would flag it as missing a label. You might try putting aria-hidden on the element, but then you would still end up with the label being on an element that lacks a role (which is illegal).

The solution I've implemented here is to move the aria-labelledby and aria-describedby attributes to the trigger.