### PR TITLE
Use XOR for `TooltipProps`

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -40,11 +40,12 @@ import {
   TooltipLabel,
   useTooltip,
 } from "./useTooltip";
+import { XOR } from "ts-xor";
 
 // Unfortunately Omit doesn't distribute nicely over sum types, so we have to
 // piece together the useTooltip options type by hand
 type TooltipProps = Omit<CommonUseTooltipProps, "isTriggerInteractive"> &
-  (TooltipLabel | TooltipDescription) & {
+  XOR<TooltipLabel, TooltipDescription> & {
     /**
      * Whether the trigger element is interactive.
      * When trigger is interactive:


### PR DESCRIPTION
Two problems when using union:
1. You can provide both a label and a description without typescript complaining.
2. [You can't do `const foo:TooltipProps["label"]` or `TooltipProps["description"]`](https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#unions-with-common-fields).