### PR TITLE
Use better type for children in TooltipProvider

### DIFF
--- a/src/components/Tooltip/TooltipProvider.tsx
+++ b/src/components/Tooltip/TooltipProvider.tsx
@@ -4,7 +4,7 @@ import React, { FC } from "react";
 export const hoverDelay = { open: 300, close: 0 };
 
 interface Props {
-  children: JSX.Element;
+  children: React.ReactNode;
 }
 
 /**


### PR DESCRIPTION
Currently you can't do:
```JSX
<TooltipProvider>
    <div>
        foo
    </div>
    <div>
        bar
    </div>
</TooltipProvider>
```