### PR TITLE
Make sure the output can be treeshaked

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "6.3.1",
   "description": "Compound components for the Web",
   "type": "module",
-  "main": "./dist/compound-web.js",
-  "module": "./dist/compound-web.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "sideEffects": false,
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "main": "./dist/compound-web.js",
   "module": "./dist/compound-web.js",
+  "sideEffects": false,
   "exports": {
     ".": {
-      "require": "./dist/compound-web.cjs",
-      "import": "./dist/compound-web.js",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts",
       "style": "./dist/style.css"
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,9 +8,11 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, "./src/index.ts"),
-      name: "CompoundWeb",
-      fileName: "compound-web",
       formats: ["es", "cjs"],
+
+      // This makes sure to keep the file structure in the output `dist` folder
+      // the same as the input `src` folder
+      fileName: "[name]",
     },
 
     target: browserslistToEsbuild(),
@@ -39,6 +41,21 @@ export default defineConfig({
         // This is a regex as we import sub-paths from the design tokens package and never the root one
         /^@vector-im\/compound-design-tokens\/.*/,
       ],
+
+      output: {
+        // This makes it so that we *don't* bundle, and instead emit individual files
+        // This is helpful for bundlers of downstream packages, as they can tree-shake properly
+        preserveModules: true,
+        preserveModulesRoot: "src",
+        // We're exporting named exports
+        exports: "named",
+      },
+
+      treeshake: {
+        // This assumes that all the modules we're importing have no side effects
+        // This is useful to make rollup import specific files when importing from barrel files
+        moduleSideEffects: false,
+      },
 
       // Without this, none of the exports are preserved in the bundle
       preserveEntrySignatures: "strict",


### PR DESCRIPTION
Fixes element-hq/compound#318

This tells rollup/vite to preserve the file structure of the source directory instead of bundling everything into a single file.

This means that as a downstream package, you'll only import what you need, and the rest will be tree-shaken for you.
Compound itself is rather small, but it has a few dependencies that only a handful of components use.
This means that if you only import a few components, it will be much smaller as it won't include `@radix-ui/*` and `@floating-ui/*` stuff.

Here is the diff on a quick hello-world project bundle analysis, which just imports a `Button`:

#### Before
<img width="1689" alt="image" src="https://github.com/user-attachments/assets/54c0c65f-5565-4d46-aa5c-58eff9314429">

Total gzipped size: 89.15kB

#### After
<img width="1693" alt="image" src="https://github.com/user-attachments/assets/a1fe5742-bc71-43f7-9508-577d681bd256">

Total gzipped size: 46.60kB

---

In MAS, it means it can code-split way better, putting a lot of compound components out of the main bundle:

<img width="1695" alt="image" src="https://github.com/user-attachments/assets/9e4018e5-f6dd-42c3-a31e-bf6718afc670">
