### PR TITLE
Remove redundant act calls

### DIFF
--- a/src/components/Form/Controls/MFA/MFA.test.tsx
+++ b/src/components/Form/Controls/MFA/MFA.test.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { describe, it, expect } from "vitest";
 import React from "react";
-import { act, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { MFAControl } from "./MFA";
@@ -45,10 +45,8 @@ describe("PasswordControl", () => {
     const { getByLabelText } = render(<MFA />);
 
     const input = getByLabelText("MFA");
-    await act(async () => {
-      await userEvent.type(input, "123");
-      await userEvent.keyboard("{tab}");
-    });
+    await userEvent.type(input, "123");
+    await userEvent.keyboard("{tab}");
 
     expect(input).toHaveAttribute("data-invalid");
   });
@@ -57,10 +55,8 @@ describe("PasswordControl", () => {
     const { getByLabelText } = render(<MFA />);
 
     const input = getByLabelText("MFA");
-    await act(async () => {
-      await userEvent.type(input, "12sf65");
-      await userEvent.keyboard("{tab}");
-    });
+    await userEvent.type(input, "12sf65");
+    await userEvent.keyboard("{tab}");
 
     expect(input).toHaveAttribute("data-invalid");
   });
@@ -69,10 +65,8 @@ describe("PasswordControl", () => {
     const { getByLabelText } = render(<MFA length={3} />);
 
     const input = getByLabelText("MFA");
-    await act(async () => {
-      await userEvent.type(input, "67890");
-      await userEvent.keyboard("{tab}");
-    });
+    await userEvent.type(input, "67890");
+    await userEvent.keyboard("{tab}");
 
     expect(input).toHaveValue("678");
     expect(input).not.toHaveAttribute("data-invalid");


### PR DESCRIPTION
user-event calls act internally, so the test produces no warnings.