### PR TITLE
fix: tooltip and menu used together

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -178,7 +178,8 @@ const TooltipAnchor: FC<TooltipAnchorProps> = ({
     if (!isValidElement(children)) return;
 
     if (isTriggerInteractive) {
-      const props = context.getReferenceProps({ ref });
+      // @ts-expect-error needed to fix https://github.com/element-hq/compound/issues/333
+      const props = context.getReferenceProps({ ref, ...children.props });
       return cloneElement(children, props);
     } else {
       // For a non-interactive trigger, we want most of the props to go on the


### PR DESCRIPTION
Closes https://github.com/element-hq/compound/issues/333
Regression due to https://github.com/element-hq/compound-web/pull/290

We need to pass the children props otherwise tooltip and menu together don't work.