### PR TITLE
fix(menu item): correct typing for onClick

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -60,7 +60,7 @@ type Props<C extends MenuItemElement> = {
    * Event callback for when the item is clicked.
    * @param e
    */
-  onClick?: MouseEventHandler<C>;
+  onClick?: MouseEventHandler;
   /**
    * The color variant of the menu item.
    * @default primary

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -60,7 +60,7 @@ type Props<C extends MenuItemElement> = {
    * Event callback for when the item is clicked.
    * @param e
    */
-  onClick?: MouseEventHandler;
+  onClick?: MouseEventHandler<HTMLElementTagNameMap[C]>;
   /**
    * The color variant of the menu item.
    * @default primary


### PR DESCRIPTION
This is embarrassing. 
I put `C` as generic of the `MouseEventHandler` which is obviously not an HTMLElement but a tag......