### PR TITLE
Specify CSS file name in vite options

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       // This makes sure to keep the file structure in the output `dist` folder
       // the same as the input `src` folder
       fileName: "[name]",
+      cssFileName: "style.css",
     },
 
     target: browserslistToEsbuild(),


### PR DESCRIPTION
Vite v6's default is to use the package name, or build.lib.fileName if specified. We do the latter, and it ended up unhelpfully being `_name_.css`.

This puts the behaviour back as it was to creating 'style.css'.