### PR TITLE
fix(context menu): open and close the menu at different position

### DIFF
--- a/src/components/Menu/ContextMenu.module.css
+++ b/src/components/Menu/ContextMenu.module.css
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025 New Vector Ltd
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+.content[data-state="closed"] {
+  animation: none;
+}

--- a/src/components/Menu/ContextMenu.tsx
+++ b/src/components/Menu/ContextMenu.tsx
@@ -17,6 +17,7 @@ import { FloatingMenu } from "./FloatingMenu";
 import { Drawer } from "vaul";
 import classnames from "classnames";
 import drawerStyles from "./DrawerMenu.module.css";
+import contextStyles from "./ContextMenu.module.css";
 import { MenuContext, MenuData, MenuItemWrapperProps } from "./MenuContext";
 import { DrawerMenu } from "./DrawerMenu";
 import { getPlatform } from "../../utils/platform";
@@ -130,7 +131,7 @@ export const ContextMenu: FC<Props> = ({
     <Root onOpenChange={onOpenChange}>
       {trigger}
       <Portal>
-        <Content asChild>
+        <Content asChild className={classnames(contextStyles.content)}>
           <FloatingMenu showTitle={showTitle} title={title}>
             {children}
           </FloatingMenu>


### PR DESCRIPTION
When reopened, the context menu doesn't change its position.
Cf https://github.com/radix-ui/primitives/issues/2611 and https://github.com/radix-ui/primitives/issues/2611#issuecomment-2118143993

## Before

https://github.com/user-attachments/assets/8fb12734-2b2c-432e-9f96-0d6a303fc4ad

## After

https://github.com/user-attachments/assets/95e73d8b-5c14-46dd-9da4-c048278f5621