### PR TITLE
Bump Vite, vitest and related packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vector-im/compound-design-tokens": "^5.0.0",
-    "@vitejs/plugin-react": "^4.0.4",
-    "@vitest/coverage-v8": "^3.0.0",
+    "@vitejs/plugin-react": "^4.6.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "browserslist-to-esbuild": "^2.0.0",
     "eslint": "^8.49.0",
     "eslint-config-prettier": "^10.0.0",
@@ -81,7 +81,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-storybook": "^9.0.16",
-    "jsdom": "^26.0.0",
+    "jsdom": "^26.1.0",
     "prettier": "3.4.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -95,9 +95,9 @@
     "stylelint-use-logical": "^2.1.0",
     "stylelint-value-no-unknown-custom-properties": "^6.0.0",
     "typescript": "^5.2.2",
-    "vite": "^6.0.0",
-    "vite-plugin-dts": "^4.0.0",
-    "vitest": "^3.0.0"
+    "vite": "^7.0.3",
+    "vite-plugin-dts": "^4.5.4",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@floating-ui/react": "^0.27.0",

--- a/src/components/ActivityMarker/__snapshots__/Pill.test.tsx.snap
+++ b/src/components/ActivityMarker/__snapshots__/Pill.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Pill > should render 1`] = `
 <DocumentFragment>
   <span
-    class="_pill_c2da8f"
+    class="_pill_3de888"
   >
     Live
   </span>

--- a/src/components/ActivityMarker/__snapshots__/Unread.test.tsx.snap
+++ b/src/components/ActivityMarker/__snapshots__/Unread.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Unread > should render 1`] = `
 <DocumentFragment>
   <div
-    class="_unread_770487"
+    class="_unread_65464f"
   >
     <div />
   </div>

--- a/src/components/ActivityMarker/__snapshots__/UnreadCounter.test.tsx.snap
+++ b/src/components/ActivityMarker/__snapshots__/UnreadCounter.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`UnreadCounter > should render 1`] = `
 <DocumentFragment>
   <span
-    class="_unread-counter_3069f5"
+    class="_unread-counter_338f41"
   >
     4
   </span>
@@ -13,7 +13,7 @@ exports[`UnreadCounter > should render 1`] = `
 exports[`UnreadCounter > should render no count 1`] = `
 <DocumentFragment>
   <div
-    class="_unread-counter_3069f5"
+    class="_unread-counter_338f41"
   />
 </DocumentFragment>
 `;

--- a/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`Alert > renders actions 1`] = `
 <DocumentFragment>
   <div
-    class="_alert_6cfd7b"
+    class="_alert_be9a30"
     data-type="info"
   >
     <svg
       aria-hidden="true"
-      class="_icon_6cfd7b"
+      class="_icon_be9a30"
       fill="currentColor"
       height="24"
       viewBox="0 0 24 24"
@@ -25,27 +25,27 @@ exports[`Alert > renders actions 1`] = `
       />
     </svg>
     <div
-      class="_content_6cfd7b"
+      class="_content_be9a30"
     >
       <div
-        class="_text-content_6cfd7b"
+        class="_text-content_be9a30"
       >
         <p
-          class="_typography_489030 _font-body-md-semibold_489030"
+          class="_typography_61e060 _font-body-md-semibold_61e060"
         >
           Long title. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </p>
         <p
-          class="_typography_489030 _font-body-sm-regular_489030"
+          class="_typography_61e060 _font-body-sm-regular_61e060"
         >
           Actions are vertically centered against alert content. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </p>
       </div>
       <div
-        class="_actions_6cfd7b"
+        class="_actions_be9a30"
       >
         <button
-          class="_button_2a1efe"
+          class="_button_0829c1"
           data-kind="primary"
           data-size="lg"
           role="button"
@@ -54,7 +54,7 @@ exports[`Alert > renders actions 1`] = `
           Yes
         </button>
         <button
-          class="_button_2a1efe"
+          class="_button_0829c1"
           data-kind="primary"
           data-size="lg"
           role="button"
@@ -66,14 +66,14 @@ exports[`Alert > renders actions 1`] = `
     </div>
     <button
       aria-label="Close"
-      class="_icon-button_e3253e _close_6cfd7b"
+      class="_icon-button_339b22 _close_be9a30"
       data-kind="primary"
       role="button"
       style="--cpd-icon-button-size: 32px;"
       tabindex="0"
     >
       <div
-        class="_indicator-icon_ab1fc6"
+        class="_indicator-icon_849abf"
         style="--cpd-icon-button-size: 100%;"
       >
         <svg
@@ -96,12 +96,12 @@ exports[`Alert > renders actions 1`] = `
 exports[`Alert > renders critical 1`] = `
 <DocumentFragment>
   <div
-    class="_alert_6cfd7b"
+    class="_alert_be9a30"
     data-type="critical"
   >
     <svg
       aria-hidden="true"
-      class="_icon_6cfd7b"
+      class="_icon_be9a30"
       fill="currentColor"
       height="24"
       viewBox="0 0 24 24"
@@ -113,18 +113,18 @@ exports[`Alert > renders critical 1`] = `
       />
     </svg>
     <div
-      class="_content_6cfd7b"
+      class="_content_be9a30"
     >
       <div
-        class="_text-content_6cfd7b"
+        class="_text-content_be9a30"
       >
         <p
-          class="_typography_489030 _font-body-md-semibold_489030"
+          class="_typography_61e060 _font-body-md-semibold_61e060"
         >
           Title
         </p>
         <p
-          class="_typography_489030 _font-body-sm-regular_489030"
+          class="_typography_61e060 _font-body-sm-regular_61e060"
         >
           Description
         </p>
@@ -132,14 +132,14 @@ exports[`Alert > renders critical 1`] = `
     </div>
     <button
       aria-label="Close"
-      class="_icon-button_e3253e _close_6cfd7b"
+      class="_icon-button_339b22 _close_be9a30"
       data-kind="primary"
       role="button"
       style="--cpd-icon-button-size: 32px;"
       tabindex="0"
     >
       <div
-        class="_indicator-icon_ab1fc6"
+        class="_indicator-icon_849abf"
         style="--cpd-icon-button-size: 100%;"
       >
         <svg
@@ -162,12 +162,12 @@ exports[`Alert > renders critical 1`] = `
 exports[`Alert > renders info 1`] = `
 <DocumentFragment>
   <div
-    class="_alert_6cfd7b"
+    class="_alert_be9a30"
     data-type="info"
   >
     <svg
       aria-hidden="true"
-      class="_icon_6cfd7b"
+      class="_icon_be9a30"
       fill="currentColor"
       height="24"
       viewBox="0 0 24 24"
@@ -184,18 +184,18 @@ exports[`Alert > renders info 1`] = `
       />
     </svg>
     <div
-      class="_content_6cfd7b"
+      class="_content_be9a30"
     >
       <div
-        class="_text-content_6cfd7b"
+        class="_text-content_be9a30"
       >
         <p
-          class="_typography_489030 _font-body-md-semibold_489030"
+          class="_typography_61e060 _font-body-md-semibold_61e060"
         >
           Title
         </p>
         <p
-          class="_typography_489030 _font-body-sm-regular_489030"
+          class="_typography_61e060 _font-body-sm-regular_61e060"
         >
           Description
         </p>
@@ -203,14 +203,14 @@ exports[`Alert > renders info 1`] = `
     </div>
     <button
       aria-label="Close"
-      class="_icon-button_e3253e _close_6cfd7b"
+      class="_icon-button_339b22 _close_be9a30"
       data-kind="primary"
       role="button"
       style="--cpd-icon-button-size: 32px;"
       tabindex="0"
     >
       <div
-        class="_indicator-icon_ab1fc6"
+        class="_indicator-icon_849abf"
         style="--cpd-icon-button-size: 100%;"
       >
         <svg
@@ -233,12 +233,12 @@ exports[`Alert > renders info 1`] = `
 exports[`Alert > renders success 1`] = `
 <DocumentFragment>
   <div
-    class="_alert_6cfd7b"
+    class="_alert_be9a30"
     data-type="success"
   >
     <svg
       aria-hidden="true"
-      class="_icon_6cfd7b"
+      class="_icon_be9a30"
       fill="currentColor"
       height="24"
       viewBox="0 0 24 24"
@@ -250,18 +250,18 @@ exports[`Alert > renders success 1`] = `
       />
     </svg>
     <div
-      class="_content_6cfd7b"
+      class="_content_be9a30"
     >
       <div
-        class="_text-content_6cfd7b"
+        class="_text-content_be9a30"
       >
         <p
-          class="_typography_489030 _font-body-md-semibold_489030"
+          class="_typography_61e060 _font-body-md-semibold_61e060"
         >
           Title
         </p>
         <p
-          class="_typography_489030 _font-body-sm-regular_489030"
+          class="_typography_61e060 _font-body-sm-regular_61e060"
         >
           Description
         </p>
@@ -269,14 +269,14 @@ exports[`Alert > renders success 1`] = `
     </div>
     <button
       aria-label="Close"
-      class="_icon-button_e3253e _close_6cfd7b"
+      class="_icon-button_339b22 _close_be9a30"
       data-kind="primary"
       role="button"
       style="--cpd-icon-button-size: 32px;"
       tabindex="0"
     >
       <div
-        class="_indicator-icon_ab1fc6"
+        class="_indicator-icon_849abf"
         style="--cpd-icon-button-size: 100%;"
       >
         <svg

--- a/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Avatar > renders the image-less avatar 1`] = `
 <DocumentFragment>
   <span
     aria-label="@bob:example.org"
-    class="_avatar_de1988 _avatar-imageless_de1988"
+    class="_avatar_814665 _avatar-imageless_814665"
     data-color="4"
     data-type="round"
     role="img"

--- a/src/components/Avatar/__snapshots__/AvatarStack.test.tsx.snap
+++ b/src/components/Avatar/__snapshots__/AvatarStack.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`AvatarStack > renders 1`] = `
 <DocumentFragment>
   <div
-    class="_stacked-avatars_de1988"
+    class="_stacked-avatars_814665"
   >
     <span
       aria-label="@alice:example.org"
-      class="_avatar_de1988 _avatar-imageless_de1988"
+      class="_avatar_814665 _avatar-imageless_814665"
       data-color="3"
       data-type="round"
       role="img"
@@ -17,7 +17,7 @@ exports[`AvatarStack > renders 1`] = `
     </span>
     <span
       aria-label="@bob:example.org"
-      class="_avatar_de1988 _avatar-imageless_de1988"
+      class="_avatar_814665 _avatar-imageless_814665"
       data-color="4"
       data-type="round"
       role="img"

--- a/src/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Badge > renders 1`] = `
 <DocumentFragment>
   <span
-    class="_typography_489030 _font-body-sm-medium_489030 _badge_f1986f"
+    class="_typography_61e060 _font-body-sm-medium_61e060 _badge_424c99"
     data-kind="default"
   />
 </DocumentFragment>

--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -2,18 +2,18 @@
 
 exports[`Breadcrumb > should render 1`] = `
 <nav
-  class="_breadcrumb_c693d3"
+  class="_breadcrumb_a10670"
 >
   <button
     aria-label="Back"
-    class="_icon-button_e3253e"
+    class="_icon-button_339b22"
     data-kind="secondary"
     role="button"
     style="--cpd-icon-button-size: 28px;"
     tabindex="0"
   >
     <div
-      class="_indicator-icon_ab1fc6"
+      class="_indicator-icon_849abf"
       style="--cpd-icon-button-size: 100%;"
     >
       <svg
@@ -30,11 +30,11 @@ exports[`Breadcrumb > should render 1`] = `
     </div>
   </button>
   <ol
-    class="_pages_c693d3"
+    class="_pages_a10670"
   >
     <li>
       <a
-        class="_link_379d57"
+        class="_link_d78ce8"
         data-kind="primary"
         data-size="small"
         rel="noreferrer noopener"
@@ -46,7 +46,7 @@ exports[`Breadcrumb > should render 1`] = `
     </li>
     <li>
       <a
-        class="_link_379d57"
+        class="_link_d78ce8"
         data-kind="primary"
         data-size="small"
         rel="noreferrer noopener"
@@ -59,7 +59,7 @@ exports[`Breadcrumb > should render 1`] = `
     <li>
       <span
         aria-current="page"
-        class="_last-page_c693d3"
+        class="_last-page_a10670"
       >
         Current page
       </span>

--- a/src/components/Button/IconButton/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/Button/IconButton/__snapshots__/IconButton.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`IconButton > renders a Default IconButton 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_icon-button_e3253e"
+    class="_icon-button_339b22"
     data-kind="primary"
     role="button"
     style="--cpd-icon-button-size: 32px;"
     tabindex="0"
   >
     <div
-      class="_indicator-icon_ab1fc6"
+      class="_indicator-icon_849abf"
       style="--cpd-icon-button-size: 100%;"
     >
       <svg
@@ -40,14 +40,14 @@ exports[`IconButton > renders a DefaultDisabled IconButton 1`] = `
 <div>
   <button
     aria-disabled="true"
-    class="_icon-button_e3253e"
+    class="_icon-button_339b22"
     data-kind="primary"
     role="button"
     style="--cpd-icon-button-size: 32px;"
     tabindex="0"
   >
     <div
-      class="_indicator-icon_ab1fc6"
+      class="_indicator-icon_849abf"
       style="--cpd-icon-button-size: 100%; --cpd-color-icon-tertiary: var(--cpd-color-icon-disabled);"
     >
       <svg
@@ -76,7 +76,7 @@ exports[`IconButton > renders a WithCriticalIndicator IconButton 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_icon-button_e3253e"
+    class="_icon-button_339b22"
     data-indicator="critical"
     data-kind="primary"
     role="button"
@@ -84,7 +84,7 @@ exports[`IconButton > renders a WithCriticalIndicator IconButton 1`] = `
     tabindex="0"
   >
     <div
-      class="_indicator-icon_ab1fc6"
+      class="_indicator-icon_849abf"
       data-indicator="critical"
       style="--cpd-icon-button-size: 100%;"
     >
@@ -114,7 +114,7 @@ exports[`IconButton > renders a WithIndicator IconButton 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_icon-button_e3253e"
+    class="_icon-button_339b22"
     data-indicator="default"
     data-kind="primary"
     role="button"
@@ -122,7 +122,7 @@ exports[`IconButton > renders a WithIndicator IconButton 1`] = `
     tabindex="0"
   >
     <div
-      class="_indicator-icon_ab1fc6"
+      class="_indicator-icon_849abf"
       data-indicator="default"
       style="--cpd-icon-button-size: 100%;"
     >
@@ -152,7 +152,7 @@ exports[`IconButton > renders a WithIndicatorDisabled IconButton 1`] = `
 <div>
   <button
     aria-disabled="true"
-    class="_icon-button_e3253e"
+    class="_icon-button_339b22"
     data-indicator="default"
     data-kind="primary"
     role="button"
@@ -160,7 +160,7 @@ exports[`IconButton > renders a WithIndicatorDisabled IconButton 1`] = `
     tabindex="0"
   >
     <div
-      class="_indicator-icon_ab1fc6"
+      class="_indicator-icon_849abf"
       data-indicator="default"
       style="--cpd-icon-button-size: 100%; --cpd-color-icon-tertiary: var(--cpd-color-icon-disabled);"
     >
@@ -190,14 +190,14 @@ exports[`IconButton > renders a WithSecondaryKind IconButton 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_icon-button_e3253e"
+    class="_icon-button_339b22"
     data-kind="secondary"
     role="button"
     style="--cpd-icon-button-size: 32px;"
     tabindex="0"
   >
     <div
-      class="_indicator-icon_ab1fc6"
+      class="_indicator-icon_849abf"
       style="--cpd-icon-button-size: 100%;"
     >
       <svg
@@ -226,14 +226,14 @@ exports[`IconButton > renders a WithSecondaryKindAndNoBackground IconButton 1`] 
 <div>
   <button
     aria-disabled="false"
-    class="_icon-button_e3253e _no-background_e3253e"
+    class="_icon-button_339b22 _no-background_339b22"
     data-kind="secondary"
     role="button"
     style="--cpd-icon-button-size: 32px;"
     tabindex="0"
   >
     <div
-      class="_indicator-icon_ab1fc6"
+      class="_indicator-icon_849abf"
       style="--cpd-icon-button-size: 100%;"
     >
       <svg
@@ -262,7 +262,7 @@ exports[`IconButton > renders a WithSuccessIndicator IconButton 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_icon-button_e3253e"
+    class="_icon-button_339b22"
     data-indicator="success"
     data-kind="primary"
     role="button"
@@ -270,7 +270,7 @@ exports[`IconButton > renders a WithSuccessIndicator IconButton 1`] = `
     tabindex="0"
   >
     <div
-      class="_indicator-icon_ab1fc6"
+      class="_indicator-icon_849abf"
       data-indicator="success"
       style="--cpd-icon-button-size: 100%;"
     >

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Button > renders a Default button 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_button_2a1efe"
+    class="_button_0829c1"
     data-kind="primary"
     data-size="lg"
     role="button"
@@ -19,7 +19,7 @@ exports[`Button > renders a Disabled button 1`] = `
 <div>
   <button
     aria-disabled="true"
-    class="_button_2a1efe"
+    class="_button_0829c1"
     data-kind="primary"
     data-size="lg"
     role="button"
@@ -34,7 +34,7 @@ exports[`Button > renders a Link button 1`] = `
 <div>
   <a
     aria-disabled="false"
-    class="_button_2a1efe"
+    class="_button_0829c1"
     data-kind="primary"
     data-size="lg"
     href="https://example.org"
@@ -50,7 +50,7 @@ exports[`Button > renders a LinkDisabled button 1`] = `
 <div>
   <a
     aria-disabled="true"
-    class="_button_2a1efe"
+    class="_button_0829c1"
     data-kind="primary"
     data-size="lg"
     href="https://example.org"
@@ -66,7 +66,7 @@ exports[`Button > renders a Primary Destructive button 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_button_2a1efe _destructive_2a1efe"
+    class="_button_0829c1 _destructive_0829c1"
     data-kind="primary"
     data-size="lg"
     role="button"
@@ -81,7 +81,7 @@ exports[`Button > renders a Primary button 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_button_2a1efe"
+    class="_button_0829c1"
     data-kind="primary"
     data-size="lg"
     role="button"
@@ -96,7 +96,7 @@ exports[`Button > renders a Secondary Destructive button 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_button_2a1efe _destructive_2a1efe"
+    class="_button_0829c1 _destructive_0829c1"
     data-kind="secondary"
     data-size="lg"
     role="button"
@@ -111,7 +111,7 @@ exports[`Button > renders a Secondary button 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_button_2a1efe"
+    class="_button_0829c1"
     data-kind="secondary"
     data-size="lg"
     role="button"
@@ -126,7 +126,7 @@ exports[`Button > renders a Small button 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_button_2a1efe"
+    class="_button_0829c1"
     data-kind="primary"
     data-size="sm"
     role="button"
@@ -141,7 +141,7 @@ exports[`Button > renders a SmallWithIcon button 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_button_2a1efe _has-icon_2a1efe"
+    class="_button_0829c1 _has-icon_0829c1"
     data-kind="primary"
     data-size="sm"
     role="button"
@@ -149,7 +149,7 @@ exports[`Button > renders a SmallWithIcon button 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="_icon_2a1efe"
+      class="_icon_0829c1"
       fill="currentColor"
       height="20"
       viewBox="0 0 24 24"
@@ -169,7 +169,7 @@ exports[`Button > renders a Tertiary Destructive button 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_button_2a1efe _destructive_2a1efe"
+    class="_button_0829c1 _destructive_0829c1"
     data-kind="tertiary"
     data-size="lg"
     role="button"
@@ -184,7 +184,7 @@ exports[`Button > renders a Tertiary button 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_button_2a1efe"
+    class="_button_0829c1"
     data-kind="tertiary"
     data-size="lg"
     role="button"
@@ -199,7 +199,7 @@ exports[`Button > renders a WithIcon button 1`] = `
 <div>
   <button
     aria-disabled="false"
-    class="_button_2a1efe _has-icon_2a1efe"
+    class="_button_0829c1 _has-icon_0829c1"
     data-kind="primary"
     data-size="lg"
     role="button"
@@ -207,7 +207,7 @@ exports[`Button > renders a WithIcon button 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="_icon_2a1efe"
+      class="_icon_0829c1"
       fill="currentColor"
       height="20"
       viewBox="0 0 24 24"

--- a/src/components/ChatFilter/__snapshots__/ChatFilter.test.tsx.snap
+++ b/src/components/ChatFilter/__snapshots__/ChatFilter.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ChatFiler > should render 1`] = `
 <button
-  class="_chat-filter_4bd40c"
+  class="_chat-filter_ad0fec"
   role="button"
   tabindex="0"
 >
@@ -13,7 +13,7 @@ exports[`ChatFiler > should render 1`] = `
 exports[`ChatFiler > should render a selected filter 1`] = `
 <button
   aria-selected="true"
-  class="_chat-filter_4bd40c"
+  class="_chat-filter_ad0fec"
   role="button"
   tabindex="0"
 >

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Dropdown > can be opened 1`] = `
 <div>
   <div
     aria-invalid="false"
-    class="_container_87c1d6"
+    class="_container_1f39d3"
   >
     <label
       id="«r8»"
@@ -16,7 +16,7 @@ exports[`Dropdown > can be opened 1`] = `
       aria-expanded="true"
       aria-haspopup="listbox"
       aria-labelledby="«r8»"
-      class="_placeholder_87c1d6"
+      class="_placeholder_1f39d3"
       role="combobox"
     >
       Select an option
@@ -33,13 +33,13 @@ exports[`Dropdown > can be opened 1`] = `
       </svg>
     </button>
     <div
-      class="_border_87c1d6 _open_87c1d6"
+      class="_border_1f39d3 _open_1f39d3"
     />
     <div
-      class="_content_87c1d6 _open_87c1d6"
+      class="_content_1f39d3 _open_1f39d3"
     >
       <ul
-        class="_content_87c1d6"
+        class="_content_1f39d3"
         id="«r9»"
         role="listbox"
       >
@@ -77,7 +77,7 @@ exports[`Dropdown > can select a value 1`] = `
 <div>
   <div
     aria-invalid="false"
-    class="_container_87c1d6"
+    class="_container_1f39d3"
   >
     <label
       id="«ra»"
@@ -106,13 +106,13 @@ exports[`Dropdown > can select a value 1`] = `
       </svg>
     </button>
     <div
-      class="_border_87c1d6 _open_87c1d6"
+      class="_border_1f39d3 _open_1f39d3"
     />
     <div
-      class="_content_87c1d6 _open_87c1d6"
+      class="_content_1f39d3 _open_1f39d3"
     >
       <ul
-        class="_content_87c1d6"
+        class="_content_1f39d3"
         id="«rb»"
         role="listbox"
       >
@@ -161,7 +161,7 @@ exports[`Dropdown > renders a Default dropdown 1`] = `
 <div>
   <div
     aria-invalid="false"
-    class="_container_87c1d6"
+    class="_container_1f39d3"
   >
     <label
       id="«r0»"
@@ -173,7 +173,7 @@ exports[`Dropdown > renders a Default dropdown 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-labelledby="«r0»"
-      class="_placeholder_87c1d6"
+      class="_placeholder_1f39d3"
       role="combobox"
     >
       Select an option
@@ -190,13 +190,13 @@ exports[`Dropdown > renders a Default dropdown 1`] = `
       </svg>
     </button>
     <div
-      class="_border_87c1d6"
+      class="_border_1f39d3"
     />
     <div
-      class="_content_87c1d6"
+      class="_content_1f39d3"
     >
       <ul
-        class="_content_87c1d6"
+        class="_content_1f39d3"
         id="«r1»"
         role="listbox"
       >
@@ -234,7 +234,7 @@ exports[`Dropdown > renders a dropdown with a default value  1`] = `
 <div>
   <div
     aria-invalid="false"
-    class="_container_87c1d6"
+    class="_container_1f39d3"
   >
     <label
       id="«r6»"
@@ -263,13 +263,13 @@ exports[`Dropdown > renders a dropdown with a default value  1`] = `
       </svg>
     </button>
     <div
-      class="_border_87c1d6"
+      class="_border_1f39d3"
     />
     <div
-      class="_content_87c1d6"
+      class="_content_1f39d3"
     >
       <ul
-        class="_content_87c1d6"
+        class="_content_1f39d3"
         id="«r7»"
         role="listbox"
       >
@@ -318,7 +318,7 @@ exports[`Dropdown > renders a dropdown with a help label 1`] = `
 <div>
   <div
     aria-invalid="false"
-    class="_container_87c1d6"
+    class="_container_1f39d3"
   >
     <label
       id="«r2»"
@@ -330,7 +330,7 @@ exports[`Dropdown > renders a dropdown with a help label 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-labelledby="«r2»"
-      class="_placeholder_87c1d6"
+      class="_placeholder_1f39d3"
       role="combobox"
     >
       Select an option
@@ -347,13 +347,13 @@ exports[`Dropdown > renders a dropdown with a help label 1`] = `
       </svg>
     </button>
     <div
-      class="_border_87c1d6"
+      class="_border_1f39d3"
     />
     <div
-      class="_content_87c1d6"
+      class="_content_1f39d3"
     >
       <ul
-        class="_content_87c1d6"
+        class="_content_1f39d3"
         id="«r3»"
         role="listbox"
       >
@@ -384,7 +384,7 @@ exports[`Dropdown > renders a dropdown with a help label 1`] = `
       </ul>
     </div>
     <span
-      class="_help_87c1d6"
+      class="_help_1f39d3"
     >
       Optional help text.
     </span>
@@ -396,7 +396,7 @@ exports[`Dropdown > renders a dropdown with an error  1`] = `
 <div>
   <div
     aria-invalid="true"
-    class="_container_87c1d6"
+    class="_container_1f39d3"
   >
     <label
       id="«r4»"
@@ -408,7 +408,7 @@ exports[`Dropdown > renders a dropdown with an error  1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-labelledby="«r4»"
-      class="_placeholder_87c1d6"
+      class="_placeholder_1f39d3"
       role="combobox"
     >
       Select an option
@@ -425,13 +425,13 @@ exports[`Dropdown > renders a dropdown with an error  1`] = `
       </svg>
     </button>
     <div
-      class="_border_87c1d6"
+      class="_border_1f39d3"
     />
     <div
-      class="_content_87c1d6"
+      class="_content_1f39d3"
     >
       <ul
-        class="_content_87c1d6"
+        class="_content_1f39d3"
         id="«r5»"
         role="listbox"
       >
@@ -462,7 +462,7 @@ exports[`Dropdown > renders a dropdown with an error  1`] = `
       </ul>
     </div>
     <span
-      class="_error_87c1d6"
+      class="_error_1f39d3"
     >
       <svg
         fill="currentColor"

--- a/src/components/Form/Controls/Action/__snapshots__/Action.test.tsx.snap
+++ b/src/components/Form/Controls/Action/__snapshots__/Action.test.tsx.snap
@@ -3,16 +3,16 @@
 exports[`ActionInput > renders 1`] = `
 <DocumentFragment>
   <div
-    class="_container_1689d3"
+    class="_container_8dd727"
     id="«r0»"
   >
     <input
-      class="_control_a839aa _control_1689d3"
+      class="_control_958ff8 _control_8dd727"
     />
     <button
       aria-controls="«r0»"
       aria-labelledby="«r1»"
-      class="_action_1689d3"
+      class="_action_8dd727"
       type="button"
     >
       <svg

--- a/src/components/Form/Controls/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/Form/Controls/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`Checkbox > renders 1`] = `
 <DocumentFragment>
   <div
-    class="_container_786d37"
+    class="_container_937330"
   >
     <input
-      class="_input_786d37"
+      class="_input_937330"
       type="checkbox"
     />
     <div
-      class="_ui_786d37"
+      class="_ui_937330"
     >
       <svg
         aria-hidden="true"

--- a/src/components/Form/Controls/EditInPlace/__snapshots__/EditInPlace.test.tsx.snap
+++ b/src/components/Form/Controls/EditInPlace/__snapshots__/EditInPlace.test.tsx.snap
@@ -3,22 +3,22 @@
 exports[`EditInPlace > disables control when disabled 1`] = `
 <DocumentFragment>
   <form
-    class="_root_dc87d2"
+    class="_root_af3470"
   >
     <div
-      class="_field_dc87d2"
+      class="_field_af3470"
     >
       <label
-        class="_label_dc87d2"
+        class="_label_af3470"
         for="radix-«r6o»"
       >
         Edit Me
       </label>
       <div
-        class="_controls_980156"
+        class="_controls_f26f0a"
       >
         <input
-          class="_control_a839aa"
+          class="_control_958ff8"
           disabled=""
           id="radix-«r6o»"
           name="input"
@@ -33,22 +33,22 @@ exports[`EditInPlace > disables control when disabled 1`] = `
 exports[`EditInPlace > displays saved label for 2 seconds after save 1`] = `
 <DocumentFragment>
   <form
-    class="_root_dc87d2"
+    class="_root_af3470"
   >
     <div
-      class="_field_dc87d2"
+      class="_field_af3470"
     >
       <label
-        class="_label_dc87d2"
+        class="_label_af3470"
         for="radix-«r59»"
       >
         Edit Me
       </label>
       <div
-        class="_controls_980156"
+        class="_controls_f26f0a"
       >
         <input
-          class="_control_a839aa"
+          class="_control_958ff8"
           id="radix-«r59»"
           name="input"
           title=""
@@ -62,25 +62,25 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 1`] = `
 exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
 <DocumentFragment>
   <form
-    class="_root_dc87d2"
+    class="_root_af3470"
   >
     <div
-      class="_field_dc87d2"
+      class="_field_af3470"
       data-valid="true"
     >
       <label
-        class="_label_dc87d2"
+        class="_label_af3470"
         data-valid="true"
         for="radix-«r59»"
       >
         Edit Me
       </label>
       <div
-        class="_controls_980156"
+        class="_controls_f26f0a"
       >
         <input
           aria-describedby="radix-«r5m»"
-          class="_control_a839aa"
+          class="_control_958ff8"
           data-valid="true"
           disabled=""
           id="radix-«r59»"
@@ -88,12 +88,12 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
           title=""
         />
         <div
-          class="_button-group_980156"
+          class="_button-group_f26f0a"
         >
           <button
             aria-disabled="true"
             aria-labelledby="«r5a»"
-            class="_button_2a1efe _has-icon_2a1efe _icon-only_2a1efe"
+            class="_button_0829c1 _has-icon_0829c1 _icon-only_0829c1"
             data-kind="primary"
             data-size="sm"
             role="button"
@@ -102,7 +102,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_2a1efe"
+              class="_icon_0829c1"
               fill="currentColor"
               height="20"
               viewBox="0 0 24 24"
@@ -117,7 +117,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
           <button
             aria-disabled="true"
             aria-labelledby="«r5f»"
-            class="_button_2a1efe _button_980156 _has-icon_2a1efe _icon-only_2a1efe"
+            class="_button_0829c1 _button_f26f0a _has-icon_0829c1 _icon-only_0829c1"
             data-kind="secondary"
             data-size="sm"
             role="button"
@@ -126,7 +126,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_2a1efe"
+              class="_icon_0829c1"
               fill="currentColor"
               height="20"
               viewBox="0 0 24 24"
@@ -141,11 +141,11 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
         </div>
       </div>
       <span
-        class="_message_dc87d2"
+        class="_message_af3470"
         id="radix-«r5m»"
       >
         <svg
-          class="_icon_01cd2d"
+          class="_icon_8010b4"
           fill="currentColor"
           height="1em"
           style="width: 20px; height: 20px;"
@@ -169,25 +169,25 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
 exports[`EditInPlace > displays saved label for 2 seconds after save 3`] = `
 <DocumentFragment>
   <form
-    class="_root_dc87d2"
+    class="_root_af3470"
   >
     <div
-      class="_field_dc87d2"
+      class="_field_af3470"
       data-valid="true"
     >
       <label
-        class="_label_dc87d2"
+        class="_label_af3470"
         data-valid="true"
         for="radix-«r59»"
       >
         Edit Me
       </label>
       <div
-        class="_controls_980156"
+        class="_controls_f26f0a"
       >
         <input
           aria-describedby="radix-«r5n»"
-          class="_control_a839aa"
+          class="_control_958ff8"
           data-valid="true"
           id="radix-«r59»"
           name="input"
@@ -195,7 +195,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 3`] = `
         />
       </div>
       <span
-        class="_message_dc87d2 _success-message_dc87d2"
+        class="_message_af3470 _success-message_af3470"
         id="radix-«r5n»"
       >
         <svg
@@ -219,22 +219,22 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 3`] = `
 exports[`EditInPlace > renders 1`] = `
 <DocumentFragment>
   <form
-    class="_root_dc87d2"
+    class="_root_af3470"
   >
     <div
-      class="_field_dc87d2"
+      class="_field_af3470"
     >
       <label
-        class="_label_dc87d2"
+        class="_label_af3470"
         for="radix-«r0»"
       >
         Edit Me
       </label>
       <div
-        class="_controls_980156"
+        class="_controls_f26f0a"
       >
         <input
-          class="_control_a839aa"
+          class="_control_958ff8"
           id="radix-«r0»"
           name="input"
           title=""
@@ -248,38 +248,38 @@ exports[`EditInPlace > renders 1`] = `
 exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
 <DocumentFragment>
   <form
-    class="_root_dc87d2"
+    class="_root_af3470"
   >
     <div
-      class="_field_dc87d2"
+      class="_field_af3470"
       data-invalid="true"
     >
       <label
-        class="_label_dc87d2"
+        class="_label_af3470"
         data-invalid="true"
         for="radix-«rf»"
       >
         Edit Me
       </label>
       <div
-        class="_controls_980156"
+        class="_controls_f26f0a"
       >
         <input
           aria-describedby="radix-«rg»"
           aria-invalid="true"
-          class="_control_a839aa"
+          class="_control_958ff8"
           data-invalid="true"
           id="radix-«rf»"
           name="input"
           title=""
         />
         <div
-          class="_button-group_980156"
+          class="_button-group_f26f0a"
         >
           <button
             aria-disabled="true"
             aria-labelledby="«rh»"
-            class="_button_2a1efe _has-icon_2a1efe _icon-only_2a1efe"
+            class="_button_0829c1 _has-icon_0829c1 _icon-only_0829c1"
             data-kind="primary"
             data-size="sm"
             role="button"
@@ -288,7 +288,7 @@ exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_2a1efe"
+              class="_icon_0829c1"
               fill="currentColor"
               height="20"
               viewBox="0 0 24 24"
@@ -303,7 +303,7 @@ exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
           <button
             aria-disabled="false"
             aria-labelledby="«rm»"
-            class="_button_2a1efe _button_980156 _has-icon_2a1efe _icon-only_2a1efe"
+            class="_button_0829c1 _button_f26f0a _has-icon_0829c1 _icon-only_0829c1"
             data-kind="secondary"
             data-size="sm"
             role="button"
@@ -312,7 +312,7 @@ exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_2a1efe"
+              class="_icon_0829c1"
               fill="currentColor"
               height="20"
               viewBox="0 0 24 24"
@@ -327,7 +327,7 @@ exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
         </div>
       </div>
       <span
-        class="_message_dc87d2 _error-message_dc87d2"
+        class="_message_af3470 _error-message_af3470"
         id="radix-«rg»"
       >
         <svg
@@ -351,22 +351,22 @@ exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
 exports[`EditInPlace > uses native form validation logic 1`] = `
 <DocumentFragment>
   <form
-    class="_root_dc87d2"
+    class="_root_af3470"
   >
     <div
-      class="_field_dc87d2"
+      class="_field_af3470"
     >
       <label
-        class="_label_dc87d2"
+        class="_label_af3470"
         for="radix-«rt»"
       >
         Edit Me
       </label>
       <div
-        class="_controls_980156"
+        class="_controls_f26f0a"
       >
         <input
-          class="_control_a839aa"
+          class="_control_958ff8"
           id="radix-«rt»"
           name="input"
           required=""
@@ -382,22 +382,22 @@ exports[`EditInPlace > uses native form validation logic 1`] = `
 exports[`EditInPlace > uses the custom error messages passed as children 1`] = `
 <DocumentFragment>
   <form
-    class="_root_dc87d2"
+    class="_root_af3470"
   >
     <div
-      class="_field_dc87d2"
+      class="_field_af3470"
     >
       <label
-        class="_label_dc87d2"
+        class="_label_af3470"
         for="radix-«r1c»"
       >
         Edit Me
       </label>
       <div
-        class="_controls_980156"
+        class="_controls_f26f0a"
       >
         <input
-          class="_control_a839aa"
+          class="_control_958ff8"
           id="radix-«r1c»"
           name="input"
           title=""

--- a/src/components/Form/Controls/MFA/__snapshots__/MFA.test.tsx.snap
+++ b/src/components/Form/Controls/MFA/__snapshots__/MFA.test.tsx.snap
@@ -10,11 +10,11 @@ exports[`PasswordControl > renders 1`] = `
         MFA
       </label>
       <div
-        class="_container_4b8c2b"
+        class="_container_8dfd49"
       >
         <input
           autocomplete="one-time-code"
-          class="_control_4b8c2b"
+          class="_control_8dfd49"
           id="radix-«r0»"
           inputmode="numeric"
           maxlength="6"
@@ -27,27 +27,27 @@ exports[`PasswordControl > renders 1`] = `
         />
         <div
           aria-hidden="true"
-          class="_digit_4b8c2b"
+          class="_digit_8dfd49"
         />
         <div
           aria-hidden="true"
-          class="_digit_4b8c2b"
+          class="_digit_8dfd49"
         />
         <div
           aria-hidden="true"
-          class="_digit_4b8c2b"
+          class="_digit_8dfd49"
         />
         <div
           aria-hidden="true"
-          class="_digit_4b8c2b"
+          class="_digit_8dfd49"
         />
         <div
           aria-hidden="true"
-          class="_digit_4b8c2b"
+          class="_digit_8dfd49"
         />
         <div
           aria-hidden="true"
-          class="_digit_4b8c2b"
+          class="_digit_8dfd49"
         />
       </div>
     </div>

--- a/src/components/Form/Controls/Password/__snapshots__/Password.test.tsx.snap
+++ b/src/components/Form/Controls/Password/__snapshots__/Password.test.tsx.snap
@@ -3,18 +3,18 @@
 exports[`PasswordControl > switches the input type > invisible 1`] = `
 <div>
   <div
-    class="_container_1689d3"
+    class="_container_8dd727"
     id="«r0»"
   >
     <input
-      class="_control_a839aa _control_1689d3"
+      class="_control_958ff8 _control_8dd727"
       type="password"
       value="p4ssw0rd!"
     />
     <button
       aria-controls="«r0»"
       aria-labelledby="«r1»"
-      class="_action_1689d3"
+      class="_action_8dd727"
       type="button"
     >
       <svg
@@ -37,18 +37,18 @@ exports[`PasswordControl > switches the input type > invisible 1`] = `
 exports[`PasswordControl > switches the input type > invisible 2`] = `
 <div>
   <div
-    class="_container_1689d3"
+    class="_container_8dd727"
     id="«r0»"
   >
     <input
-      class="_control_a839aa _control_1689d3"
+      class="_control_958ff8 _control_8dd727"
       type="password"
       value="p4ssw0rd!"
     />
     <button
       aria-controls="«r0»"
       aria-labelledby="«r1»"
-      class="_action_1689d3"
+      class="_action_8dd727"
       type="button"
     >
       <svg
@@ -71,18 +71,18 @@ exports[`PasswordControl > switches the input type > invisible 2`] = `
 exports[`PasswordControl > switches the input type > visible 1`] = `
 <div>
   <div
-    class="_container_1689d3"
+    class="_container_8dd727"
     id="«r0»"
   >
     <input
-      class="_control_a839aa _control_1689d3"
+      class="_control_958ff8 _control_8dd727"
       type="text"
       value="p4ssw0rd!"
     />
     <button
       aria-controls="«r0»"
       aria-labelledby="«r1»"
-      class="_action_1689d3"
+      class="_action_8dd727"
       type="button"
     >
       <svg

--- a/src/components/Form/Controls/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/src/components/Form/Controls/Radio/__snapshots__/Radio.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`Radio > renders 1`] = `
 <DocumentFragment>
   <div
-    class="_container_5881bc"
+    class="_container_8b5535"
   >
     <input
-      class="_input_5881bc"
+      class="_input_8b5535"
       type="radio"
     />
     <div
-      class="_ui_5881bc"
+      class="_ui_8b5535"
     />
   </div>
 </DocumentFragment>

--- a/src/components/Form/Controls/SettingsToggle/__snapshots__/SettingsToggle.test.tsx.snap
+++ b/src/components/Form/Controls/SettingsToggle/__snapshots__/SettingsToggle.test.tsx.snap
@@ -4,30 +4,30 @@ exports[`Toggle > renders 1`] = `
 <DocumentFragment>
   <form>
     <div
-      class="_inline-field_dc87d2"
+      class="_inline-field_af3470"
     >
       <div
-        class="_inline-field-control_dc87d2"
+        class="_inline-field-control_af3470"
       >
         <div
-          class="_container_adcb29"
+          class="_container_d9763f"
         >
           <input
-            class="_input_adcb29"
+            class="_input_d9763f"
             id="«r0»"
             role="switch"
             type="checkbox"
           />
           <div
-            class="_ui_adcb29"
+            class="_ui_d9763f"
           />
         </div>
       </div>
       <div
-        class="_inline-field-body_dc87d2"
+        class="_inline-field-body_af3470"
       >
         <label
-          class="_label_dc87d2"
+          class="_label_af3470"
           for="«r0»"
         >
           Simple setting
@@ -42,36 +42,36 @@ exports[`Toggle > renders with a help message 1`] = `
 <DocumentFragment>
   <form>
     <div
-      class="_inline-field_dc87d2"
+      class="_inline-field_af3470"
     >
       <div
-        class="_inline-field-control_dc87d2"
+        class="_inline-field-control_af3470"
       >
         <div
-          class="_container_adcb29"
+          class="_container_d9763f"
         >
           <input
-            class="_input_adcb29"
+            class="_input_d9763f"
             id="«r2»"
             role="switch"
             type="checkbox"
           />
           <div
-            class="_ui_adcb29"
+            class="_ui_d9763f"
           />
         </div>
       </div>
       <div
-        class="_inline-field-body_dc87d2"
+        class="_inline-field-body_af3470"
       >
         <label
-          class="_label_dc87d2"
+          class="_label_af3470"
           for="«r2»"
         >
           Simple setting
         </label>
         <span
-          class="_message_dc87d2 _help-message_dc87d2"
+          class="_message_af3470 _help-message_af3470"
           id="radix-«r4»"
         >
           A simple setting to control things
@@ -86,36 +86,36 @@ exports[`renders with a disabled message (disabled=false) 1`] = `
 <DocumentFragment>
   <form>
     <div
-      class="_inline-field_dc87d2"
+      class="_inline-field_af3470"
     >
       <div
-        class="_inline-field-control_dc87d2"
+        class="_inline-field-control_af3470"
       >
         <div
-          class="_container_adcb29"
+          class="_container_d9763f"
         >
           <input
-            class="_input_adcb29"
+            class="_input_d9763f"
             id="«r9»"
             role="switch"
             type="checkbox"
           />
           <div
-            class="_ui_adcb29"
+            class="_ui_d9763f"
           />
         </div>
       </div>
       <div
-        class="_inline-field-body_dc87d2"
+        class="_inline-field-body_af3470"
       >
         <label
-          class="_label_dc87d2"
+          class="_label_af3470"
           for="«r9»"
         >
           Simple setting
         </label>
         <span
-          class="_message_dc87d2 _help-message_dc87d2"
+          class="_message_af3470 _help-message_af3470"
           id="radix-«rb»"
         >
           A simple setting to control things
@@ -130,43 +130,43 @@ exports[`renders with a disabled message (disabled=true) 1`] = `
 <DocumentFragment>
   <form>
     <div
-      class="_inline-field_dc87d2"
+      class="_inline-field_af3470"
     >
       <div
-        class="_inline-field-control_dc87d2"
+        class="_inline-field-control_af3470"
       >
         <div
-          class="_container_adcb29"
+          class="_container_d9763f"
         >
           <input
-            class="_input_adcb29"
+            class="_input_d9763f"
             disabled=""
             id="«r5»"
             role="switch"
             type="checkbox"
           />
           <div
-            class="_ui_adcb29"
+            class="_ui_d9763f"
           />
         </div>
       </div>
       <div
-        class="_inline-field-body_dc87d2"
+        class="_inline-field-body_af3470"
       >
         <label
-          class="_label_dc87d2"
+          class="_label_af3470"
           for="«r5»"
         >
           Simple setting
         </label>
         <span
-          class="_message_dc87d2 _help-message_dc87d2"
+          class="_message_af3470 _help-message_af3470"
           id="radix-«r7»"
         >
           A simple setting to control things
         </span>
         <span
-          class="_message_dc87d2 _help-message_dc87d2"
+          class="_message_af3470 _help-message_af3470"
           id="radix-«r8»"
         >
           This is disabled.

--- a/src/components/Form/Controls/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Form/Controls/Text/__snapshots__/Text.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Text /> > renders a disabled input 1`] = `
 <div>
   <input
-    class="_control_a839aa"
+    class="_control_958ff8"
     disabled=""
     placeholder=""
     value="Disabled"
@@ -14,7 +14,7 @@ exports[`<Text /> > renders a disabled input 1`] = `
 exports[`<Text /> > renders a filled input 1`] = `
 <div>
   <input
-    class="_control_a839aa"
+    class="_control_958ff8"
     placeholder=""
     value="-> 1x2x3"
   />
@@ -24,7 +24,7 @@ exports[`<Text /> > renders a filled input 1`] = `
 exports[`<Text /> > renders a input with ligatures enable 1`] = `
 <div>
   <input
-    class="_control_a839aa _enable-ligatures_a839aa"
+    class="_control_958ff8 _enable-ligatures_958ff8"
     placeholder=""
     value="-> 1x2x3"
   />
@@ -34,7 +34,7 @@ exports[`<Text /> > renders a input with ligatures enable 1`] = `
 exports[`<Text /> > renders a read only input 1`] = `
 <div>
   <input
-    class="_control_a839aa"
+    class="_control_958ff8"
     placeholder=""
     readonly=""
     value="Read only"
@@ -45,7 +45,7 @@ exports[`<Text /> > renders a read only input 1`] = `
 exports[`<Text /> > renders an empty input 1`] = `
 <div>
   <input
-    class="_control_a839aa"
+    class="_control_958ff8"
     placeholder=""
   />
 </div>
@@ -54,7 +54,7 @@ exports[`<Text /> > renders an empty input 1`] = `
 exports[`<Text /> > renders an invalid input 1`] = `
 <div>
   <input
-    class="_control_a839aa"
+    class="_control_958ff8"
     data-invalid="true"
     placeholder=""
     value="Invalid"

--- a/src/components/Form/Controls/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/components/Form/Controls/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`Toggle > renders 1`] = `
 <DocumentFragment>
   <div
-    class="_container_adcb29"
+    class="_container_d9763f"
   >
     <input
-      class="_input_adcb29"
+      class="_input_d9763f"
       role="switch"
       type="checkbox"
     />
     <div
-      class="_ui_adcb29"
+      class="_ui_d9763f"
     />
   </div>
 </DocumentFragment>

--- a/src/components/Glass/__snapshots__/Glass.test.tsx.snap
+++ b/src/components/Glass/__snapshots__/Glass.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Glass > renders 1`] = `
 <DocumentFragment>
   <div
-    class="_glass_a755bb"
+    class="_glass_77c50d"
   >
     <div>
       ooh, shiny…

--- a/src/components/Icon/BigIcon/__snapshots__/BigIcon.test.tsx.snap
+++ b/src/components/Icon/BigIcon/__snapshots__/BigIcon.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`BigIcon > renders a destructive big icon 1`] = `
 <div>
   <div
-    class="_content_ce8c5a _destructive_ce8c5a"
+    class="_content_6ba1e4 _destructive_6ba1e4"
     data-size="large"
   >
     <svg
@@ -24,7 +24,7 @@ exports[`BigIcon > renders a destructive big icon 1`] = `
 exports[`BigIcon > renders a large big icon 1`] = `
 <div>
   <div
-    class="_content_ce8c5a"
+    class="_content_6ba1e4"
     data-size="large"
   >
     <svg
@@ -45,7 +45,7 @@ exports[`BigIcon > renders a large big icon 1`] = `
 exports[`BigIcon > renders a medium big icon 1`] = `
 <div>
   <div
-    class="_content_ce8c5a"
+    class="_content_6ba1e4"
     data-size="medium"
   >
     <svg
@@ -66,7 +66,7 @@ exports[`BigIcon > renders a medium big icon 1`] = `
 exports[`BigIcon > renders a small big icon 1`] = `
 <div>
   <div
-    class="_content_ce8c5a"
+    class="_content_6ba1e4"
     data-size="small"
   >
     <svg
@@ -87,7 +87,7 @@ exports[`BigIcon > renders a small big icon 1`] = `
 exports[`BigIcon > renders a success big icon 1`] = `
 <div>
   <div
-    class="_content_ce8c5a _success_ce8c5a"
+    class="_content_6ba1e4 _success_6ba1e4"
     data-size="large"
   >
     <svg

--- a/src/components/Icon/IndicatorIcon/__snapshots__/IndicatorIcon.test.tsx.snap
+++ b/src/components/Icon/IndicatorIcon/__snapshots__/IndicatorIcon.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`IconButton > renders a Default IconButton 1`] = `
 <div>
   <div
-    class="_indicator-icon_ab1fc6"
+    class="_indicator-icon_849abf"
     style="--cpd-icon-button-size: 32px;"
   >
     <svg
@@ -27,7 +27,7 @@ exports[`IconButton > renders a Default IconButton 1`] = `
 exports[`IconButton > renders a WithCriticalIndicator IconButton 1`] = `
 <div>
   <div
-    class="_indicator-icon_ab1fc6"
+    class="_indicator-icon_849abf"
     data-indicator="critical"
     style="--cpd-icon-button-size: 32px;"
   >
@@ -52,7 +52,7 @@ exports[`IconButton > renders a WithCriticalIndicator IconButton 1`] = `
 exports[`IconButton > renders a WithIndicator IconButton 1`] = `
 <div>
   <div
-    class="_indicator-icon_ab1fc6"
+    class="_indicator-icon_849abf"
     data-indicator="default"
     style="--cpd-icon-button-size: 32px;"
   >
@@ -77,7 +77,7 @@ exports[`IconButton > renders a WithIndicator IconButton 1`] = `
 exports[`IconButton > renders a WithSuccessIndicator IconButton 1`] = `
 <div>
   <div
-    class="_indicator-icon_ab1fc6"
+    class="_indicator-icon_849abf"
     data-indicator="success"
     style="--cpd-icon-button-size: 32px;"
   >

--- a/src/components/InlineSpinner/__snapshots__/InlineSpinner.test.tsx.snap
+++ b/src/components/InlineSpinner/__snapshots__/InlineSpinner.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`InlineSpinner > renders 1`] = `
 <DocumentFragment>
   <svg
-    class="_icon_01cd2d"
+    class="_icon_8010b4"
     fill="currentColor"
     height="1em"
     style="width: 20px; height: 20px;"

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Link > renders 1`] = `
 <DocumentFragment>
   <a
-    class="_link_379d57"
+    class="_link_d78ce8"
     data-kind="primary"
     data-size="medium"
     rel="noreferrer noopener"
@@ -14,7 +14,7 @@ exports[`Link > renders 1`] = `
 exports[`Link > renders width a small size 1`] = `
 <DocumentFragment>
   <a
-    class="_link_379d57"
+    class="_link_d78ce8"
     data-kind="primary"
     data-size="small"
     rel="noreferrer noopener"

--- a/src/components/Menu/__snapshots__/CheckboxMenuItem.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/CheckboxMenuItem.test.tsx.snap
@@ -4,21 +4,21 @@ exports[`CheckboxMenuItem > renders 1`] = `
 <DocumentFragment>
   <div
     aria-checked="false"
-    class="_item_831119 _interactive_831119"
+    class="_item_9618f6 _interactive_9618f6"
     data-kind="primary"
     role="menuitemcheckbox"
   >
     <div
-      class="_container_786d37 _icon_831119"
+      class="_container_937330 _icon_9618f6"
     >
       <input
         aria-hidden="true"
-        class="_input_786d37"
+        class="_input_937330"
         id="«r0»"
         type="checkbox"
       />
       <div
-        class="_ui_786d37"
+        class="_ui_937330"
       >
         <svg
           aria-hidden="true"
@@ -35,7 +35,7 @@ exports[`CheckboxMenuItem > renders 1`] = `
       </div>
     </div>
     <span
-      class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+      class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
     >
       Always show
     </span>

--- a/src/components/Menu/__snapshots__/DrawerMenu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/DrawerMenu.test.tsx.snap
@@ -4,21 +4,21 @@ exports[`DrawerMenu > renders 1`] = `
 <DocumentFragment>
   <div
     aria-label="Settings"
-    class="_drawer_31bf0e"
+    class="_drawer_fead1c"
     data-platform="other"
     role="menu"
   >
     <div
-      class="_body_31bf0e"
+      class="_body_fead1c"
     >
       <button
-        class="_item_831119 _interactive_831119"
+        class="_item_9618f6 _interactive_9618f6"
         data-kind="primary"
         role="menuitem"
       >
         <svg
           aria-hidden="true"
-          class="_icon_831119"
+          class="_icon_9618f6"
           fill="currentColor"
           height="24"
           viewBox="0 0 24 24"
@@ -36,13 +36,13 @@ exports[`DrawerMenu > renders 1`] = `
           />
         </svg>
         <span
-          class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+          class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
         >
           Profile
         </span>
         <svg
           aria-hidden="true"
-          class="_nav-hint_831119"
+          class="_nav-hint_9618f6"
           fill="currentColor"
           height="24"
           viewBox="8 0 8 24"
@@ -55,19 +55,19 @@ exports[`DrawerMenu > renders 1`] = `
         </svg>
       </button>
       <div
-        class="_separator_162edc"
+        class="_separator_59a6a1"
         data-kind="primary"
         data-orientation="horizontal"
         role="separator"
       />
       <button
-        class="_item_831119 _interactive_831119"
+        class="_item_9618f6 _interactive_9618f6"
         data-kind="critical"
         role="menuitem"
       >
         <svg
           aria-hidden="true"
-          class="_icon_831119"
+          class="_icon_9618f6"
           fill="currentColor"
           height="24"
           viewBox="0 0 24 24"
@@ -82,13 +82,13 @@ exports[`DrawerMenu > renders 1`] = `
           />
         </svg>
         <span
-          class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+          class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
         >
           Sign out
         </span>
         <svg
           aria-hidden="true"
-          class="_nav-hint_831119"
+          class="_nav-hint_9618f6"
           fill="currentColor"
           height="24"
           viewBox="8 0 8 24"

--- a/src/components/Menu/__snapshots__/FloatingMenu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/FloatingMenu.test.tsx.snap
@@ -4,23 +4,23 @@ exports[`FloatingMenu > renders 1`] = `
 <DocumentFragment>
   <div
     aria-labelledby="«r0»"
-    class="_menu_3295a1"
+    class="_menu_8d7946"
     role="menu"
   >
     <h3
-      class="_typography_489030 _font-body-sm-semibold_489030 _menu-title_7bbc38 _title_3295a1"
+      class="_typography_61e060 _font-body-sm-semibold_61e060 _menu-title_096aee _title_8d7946"
       id="«r0»"
     >
       Settings
     </h3>
     <button
-      class="_item_831119 _interactive_831119"
+      class="_item_9618f6 _interactive_9618f6"
       data-kind="primary"
       role="menuitem"
     >
       <svg
         aria-hidden="true"
-        class="_icon_831119"
+        class="_icon_9618f6"
         fill="currentColor"
         height="24"
         viewBox="0 0 24 24"
@@ -38,13 +38,13 @@ exports[`FloatingMenu > renders 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+        class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
       >
         Profile
       </span>
       <svg
         aria-hidden="true"
-        class="_nav-hint_831119"
+        class="_nav-hint_9618f6"
         fill="currentColor"
         height="24"
         viewBox="8 0 8 24"
@@ -57,19 +57,19 @@ exports[`FloatingMenu > renders 1`] = `
       </svg>
     </button>
     <div
-      class="_separator_162edc"
+      class="_separator_59a6a1"
       data-kind="primary"
       data-orientation="horizontal"
       role="separator"
     />
     <button
-      class="_item_831119 _interactive_831119"
+      class="_item_9618f6 _interactive_9618f6"
       data-kind="critical"
       role="menuitem"
     >
       <svg
         aria-hidden="true"
-        class="_icon_831119"
+        class="_icon_9618f6"
         fill="currentColor"
         height="24"
         viewBox="0 0 24 24"
@@ -84,13 +84,13 @@ exports[`FloatingMenu > renders 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+        class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
       >
         Sign out
       </span>
       <svg
         aria-hidden="true"
-        class="_nav-hint_831119"
+        class="_nav-hint_9618f6"
         fill="currentColor"
         height="24"
         viewBox="8 0 8 24"

--- a/src/components/Menu/__snapshots__/MenuItem.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/MenuItem.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`MenuItem > renders 1`] = `
 <DocumentFragment>
   <button
-    class="_item_831119 _interactive_831119"
+    class="_item_9618f6 _interactive_9618f6"
     data-kind="critical"
     role="menuitem"
   >
     <svg
       aria-hidden="true"
-      class="_icon_831119"
+      class="_icon_9618f6"
       fill="currentColor"
       height="24"
       viewBox="0 0 24 24"
@@ -24,13 +24,13 @@ exports[`MenuItem > renders 1`] = `
       />
     </svg>
     <span
-      class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+      class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
     >
       Leave room
     </span>
     <svg
       aria-hidden="true"
-      class="_nav-hint_831119"
+      class="_nav-hint_9618f6"
       fill="currentColor"
       height="24"
       viewBox="8 0 8 24"
@@ -51,14 +51,14 @@ exports[`MenuItem > renders a Critical Disabled menu item 1`] = `
     style="width: 300px;"
   >
     <button
-      class="_item_831119 _interactive_831119 _disabled_831119"
+      class="_item_9618f6 _interactive_9618f6 _disabled_9618f6"
       data-kind="critical"
       disabled=""
       role="menuitem"
     >
       <svg
         aria-hidden="true"
-        class="_icon_831119"
+        class="_icon_9618f6"
         fill="currentColor"
         height="24"
         viewBox="0 0 24 24"
@@ -70,13 +70,13 @@ exports[`MenuItem > renders a Critical Disabled menu item 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+        class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
       >
         Menu item
       </span>
       <svg
         aria-hidden="true"
-        class="_nav-hint_831119"
+        class="_nav-hint_9618f6"
         fill="currentColor"
         height="24"
         viewBox="8 0 8 24"
@@ -88,7 +88,7 @@ exports[`MenuItem > renders a Critical Disabled menu item 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-sm-regular_489030"
+        class="_typography_61e060 _font-body-sm-regular_61e060"
       >
         99
       </span>
@@ -103,13 +103,13 @@ exports[`MenuItem > renders a Critical menu item 1`] = `
     style="width: 300px;"
   >
     <button
-      class="_item_831119 _interactive_831119"
+      class="_item_9618f6 _interactive_9618f6"
       data-kind="critical"
       role="menuitem"
     >
       <svg
         aria-hidden="true"
-        class="_icon_831119"
+        class="_icon_9618f6"
         fill="currentColor"
         height="24"
         viewBox="0 0 24 24"
@@ -121,13 +121,13 @@ exports[`MenuItem > renders a Critical menu item 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+        class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
       >
         Menu item
       </span>
       <svg
         aria-hidden="true"
-        class="_nav-hint_831119"
+        class="_nav-hint_9618f6"
         fill="currentColor"
         height="24"
         viewBox="8 0 8 24"
@@ -139,7 +139,7 @@ exports[`MenuItem > renders a Critical menu item 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-sm-regular_489030"
+        class="_typography_61e060 _font-body-sm-regular_61e060"
       >
         99
       </span>
@@ -154,14 +154,14 @@ exports[`MenuItem > renders a Primary Disabled menu item 1`] = `
     style="width: 300px;"
   >
     <button
-      class="_item_831119 _interactive_831119 _disabled_831119"
+      class="_item_9618f6 _interactive_9618f6 _disabled_9618f6"
       data-kind="primary"
       disabled=""
       role="menuitem"
     >
       <svg
         aria-hidden="true"
-        class="_icon_831119"
+        class="_icon_9618f6"
         fill="currentColor"
         height="24"
         viewBox="0 0 24 24"
@@ -173,13 +173,13 @@ exports[`MenuItem > renders a Primary Disabled menu item 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+        class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
       >
         Menu item
       </span>
       <svg
         aria-hidden="true"
-        class="_nav-hint_831119"
+        class="_nav-hint_9618f6"
         fill="currentColor"
         height="24"
         viewBox="8 0 8 24"
@@ -191,7 +191,7 @@ exports[`MenuItem > renders a Primary Disabled menu item 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-sm-regular_489030"
+        class="_typography_61e060 _font-body-sm-regular_61e060"
       >
         99
       </span>
@@ -206,13 +206,13 @@ exports[`MenuItem > renders a Primary menu item 1`] = `
     style="width: 300px;"
   >
     <button
-      class="_item_831119 _interactive_831119"
+      class="_item_9618f6 _interactive_9618f6"
       data-kind="primary"
       role="menuitem"
     >
       <svg
         aria-hidden="true"
-        class="_icon_831119"
+        class="_icon_9618f6"
         fill="currentColor"
         height="24"
         viewBox="0 0 24 24"
@@ -224,13 +224,13 @@ exports[`MenuItem > renders a Primary menu item 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+        class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
       >
         Menu item
       </span>
       <svg
         aria-hidden="true"
-        class="_nav-hint_831119"
+        class="_nav-hint_9618f6"
         fill="currentColor"
         height="24"
         viewBox="8 0 8 24"
@@ -242,7 +242,7 @@ exports[`MenuItem > renders a Primary menu item 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-sm-regular_489030"
+        class="_typography_61e060 _font-body-sm-regular_61e060"
       >
         99
       </span>
@@ -257,13 +257,13 @@ exports[`MenuItem > renders a menu item with a long label 1`] = `
     style="width: 300px;"
   >
     <button
-      class="_item_831119 _interactive_831119"
+      class="_item_9618f6 _interactive_9618f6"
       data-kind="primary"
       role="menuitem"
     >
       <svg
         aria-hidden="true"
-        class="_icon_831119"
+        class="_icon_9618f6"
         fill="currentColor"
         height="24"
         viewBox="0 0 24 24"
@@ -275,13 +275,13 @@ exports[`MenuItem > renders a menu item with a long label 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+        class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
       </span>
       <svg
         aria-hidden="true"
-        class="_nav-hint_831119"
+        class="_nav-hint_9618f6"
         fill="currentColor"
         height="24"
         viewBox="8 0 8 24"
@@ -293,7 +293,7 @@ exports[`MenuItem > renders a menu item with a long label 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-sm-regular_489030"
+        class="_typography_61e060 _font-body-sm-regular_61e060"
       >
         99
       </span>
@@ -308,13 +308,13 @@ exports[`MenuItem > renders a menu item with a long label and children 1`] = `
     style="width: 300px;"
   >
     <button
-      class="_item_831119 _interactive_831119"
+      class="_item_9618f6 _interactive_9618f6"
       data-kind="primary"
       role="menuitem"
     >
       <svg
         aria-hidden="true"
-        class="_icon_831119"
+        class="_icon_9618f6"
         fill="currentColor"
         height="24"
         viewBox="0 0 24 24"
@@ -326,13 +326,13 @@ exports[`MenuItem > renders a menu item with a long label and children 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+        class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, empor incididunt ut labore et dolore magna aliqua.
       </span>
       <svg
         aria-hidden="true"
-        class="_nav-hint_831119"
+        class="_nav-hint_9618f6"
         fill="currentColor"
         height="24"
         viewBox="8 0 8 24"
@@ -344,7 +344,7 @@ exports[`MenuItem > renders a menu item with a long label and children 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-sm-regular_489030"
+        class="_typography_61e060 _font-body-sm-regular_61e060"
       >
         Longer children too
       </span>
@@ -359,13 +359,13 @@ exports[`MenuItem > renders a menu item without a chevron 1`] = `
     style="width: 300px;"
   >
     <button
-      class="_item_831119 _interactive_831119"
+      class="_item_9618f6 _interactive_9618f6"
       data-kind="primary"
       role="menuitem"
     >
       <svg
         aria-hidden="true"
-        class="_icon_831119"
+        class="_icon_9618f6"
         fill="currentColor"
         height="24"
         viewBox="0 0 24 24"
@@ -377,12 +377,12 @@ exports[`MenuItem > renders a menu item without a chevron 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+        class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
       >
         Menu item
       </span>
       <span
-        class="_typography_489030 _font-body-sm-regular_489030"
+        class="_typography_61e060 _font-body-sm-regular_61e060"
       >
         99
       </span>
@@ -397,18 +397,18 @@ exports[`MenuItem > renders a menu item without an icon 1`] = `
     style="width: 300px;"
   >
     <button
-      class="_item_831119 _interactive_831119 _no-icon_831119"
+      class="_item_9618f6 _interactive_9618f6 _no-icon_9618f6"
       data-kind="primary"
       role="menuitem"
     >
       <span
-        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+        class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
       >
         Menu item
       </span>
       <svg
         aria-hidden="true"
-        class="_nav-hint_831119"
+        class="_nav-hint_9618f6"
         fill="currentColor"
         height="24"
         viewBox="8 0 8 24"
@@ -420,7 +420,7 @@ exports[`MenuItem > renders a menu item without an icon 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-sm-regular_489030"
+        class="_typography_61e060 _font-body-sm-regular_61e060"
       >
         99
       </span>
@@ -432,13 +432,13 @@ exports[`MenuItem > renders a menu item without an icon 1`] = `
 exports[`MenuItem > renders with a child 1`] = `
 <DocumentFragment>
   <button
-    class="_item_831119 _interactive_831119"
+    class="_item_9618f6 _interactive_9618f6"
     data-kind="primary"
     role="menuitem"
   >
     <svg
       aria-hidden="true"
-      class="_icon_831119"
+      class="_icon_9618f6"
       fill="currentColor"
       height="24"
       viewBox="0 0 24 24"
@@ -456,13 +456,13 @@ exports[`MenuItem > renders with a child 1`] = `
       />
     </svg>
     <span
-      class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+      class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
     >
       People
     </span>
     <svg
       aria-hidden="true"
-      class="_nav-hint_831119"
+      class="_nav-hint_9618f6"
       fill="currentColor"
       height="24"
       viewBox="8 0 8 24"
@@ -474,7 +474,7 @@ exports[`MenuItem > renders with a child 1`] = `
       />
     </svg>
     <span
-      class="_typography_489030 _font-body-sm-regular_489030"
+      class="_typography_61e060 _font-body-sm-regular_61e060"
     >
       10
     </span>
@@ -488,22 +488,22 @@ exports[`MenuItem > renders with an component as an Icon 1`] = `
     style="width: 300px;"
   >
     <button
-      class="_item_831119 _interactive_831119"
+      class="_item_9618f6 _interactive_9618f6"
       data-kind="primary"
       role="menuitem"
     >
       <div
-        class="_icon_831119"
+        class="_icon_9618f6"
         style="height: 24px; width: 48px; background-color: teal;"
       />
       <span
-        class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+        class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
       >
         Menu item
       </span>
       <svg
         aria-hidden="true"
-        class="_nav-hint_831119"
+        class="_nav-hint_9618f6"
         fill="currentColor"
         height="24"
         viewBox="8 0 8 24"
@@ -515,7 +515,7 @@ exports[`MenuItem > renders with an component as an Icon 1`] = `
         />
       </svg>
       <span
-        class="_typography_489030 _font-body-sm-regular_489030"
+        class="_typography_61e060 _font-body-sm-regular_61e060"
       >
         99
       </span>
@@ -527,13 +527,13 @@ exports[`MenuItem > renders with an component as an Icon 1`] = `
 exports[`MenuItem > renders without a label 1`] = `
 <DocumentFragment>
   <button
-    class="_item_831119 _interactive_831119 _no-label_831119"
+    class="_item_9618f6 _interactive_9618f6 _no-label_9618f6"
     data-kind="primary"
     role="menuitem"
   >
     <svg
       aria-hidden="true"
-      class="_icon_831119"
+      class="_icon_9618f6"
       fill="currentColor"
       height="24"
       viewBox="0 0 24 24"
@@ -551,7 +551,7 @@ exports[`MenuItem > renders without a label 1`] = `
     </svg>
     <svg
       aria-hidden="true"
-      class="_nav-hint_831119"
+      class="_nav-hint_9618f6"
       fill="currentColor"
       height="24"
       viewBox="8 0 8 24"

--- a/src/components/Menu/__snapshots__/MenuTitle.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/MenuTitle.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MenuTitle > renders 1`] = `
 <DocumentFragment>
   <h3
-    class="_typography_489030 _font-body-sm-semibold_489030 _menu-title_7bbc38"
+    class="_typography_61e060 _font-body-sm-semibold_61e060 _menu-title_096aee"
   >
     Title
   </h3>

--- a/src/components/Menu/__snapshots__/RadioMenuItem.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/RadioMenuItem.test.tsx.snap
@@ -4,25 +4,25 @@ exports[`RadioMenuItem > renders 1`] = `
 <DocumentFragment>
   <div
     aria-checked="false"
-    class="_item_831119 _interactive_831119"
+    class="_item_9618f6 _interactive_9618f6"
     data-kind="primary"
     role="menuitemradio"
   >
     <div
-      class="_container_5881bc _icon_831119"
+      class="_container_8b5535 _icon_9618f6"
     >
       <input
         aria-hidden="true"
-        class="_input_5881bc"
+        class="_input_8b5535"
         id="«r0»"
         type="radio"
       />
       <div
-        class="_ui_5881bc"
+        class="_ui_8b5535"
       />
     </div>
     <span
-      class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+      class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
     >
       Always show
     </span>

--- a/src/components/Menu/__snapshots__/ToggleMenuItem.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/ToggleMenuItem.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`ToggleMenuItem > renders 1`] = `
 <DocumentFragment>
   <div
     aria-checked="false"
-    class="_item_831119 _interactive_831119"
+    class="_item_9618f6 _interactive_9618f6"
     data-kind="primary"
     role="menuitemcheckbox"
   >
     <svg
       aria-hidden="true"
-      class="_icon_831119"
+      class="_icon_9618f6"
       fill="currentColor"
       height="24"
       viewBox="0 0 24 24"
@@ -22,22 +22,22 @@ exports[`ToggleMenuItem > renders 1`] = `
       />
     </svg>
     <span
-      class="_typography_489030 _font-body-md-medium_489030 _label_831119"
+      class="_typography_61e060 _font-body-md-medium_61e060 _label_9618f6"
     >
       Always show
     </span>
     <div
-      class="_container_adcb29"
+      class="_container_d9763f"
     >
       <input
         aria-hidden="true"
-        class="_input_adcb29"
+        class="_input_d9763f"
         id="«r0»"
         role="switch"
         type="checkbox"
       />
       <div
-        class="_ui_adcb29"
+        class="_ui_d9763f"
       />
     </div>
   </div>

--- a/src/components/Nav/__snapshots__/NavBar.test.tsx.snap
+++ b/src/components/Nav/__snapshots__/NavBar.test.tsx.snap
@@ -4,51 +4,51 @@ exports[`<NavBar /> > render a default nav bar 1`] = `
 <div>
   <nav
     aria-label="Main"
-    class="_nav-bar_eb2dec"
+    class="_nav-bar_0471db"
     role="navigation"
   >
     <ul
-      class="_nav-bar-items_eb2dec"
+      class="_nav-bar-items_0471db"
     >
       <li
-        class="_nav-tab_eb2dec"
+        class="_nav-tab_0471db"
         role="presentation"
       >
         <button
-          class="_nav-item_eb2dec"
+          class="_nav-item_0471db"
         >
           Info
         </button>
       </li>
       <li
-        class="_nav-tab_eb2dec"
+        class="_nav-tab_0471db"
         data-current="true"
         role="presentation"
       >
         <button
           aria-current="true"
-          class="_nav-item_eb2dec"
+          class="_nav-item_0471db"
         >
           People
         </button>
       </li>
       <li
-        class="_nav-tab_eb2dec"
+        class="_nav-tab_0471db"
         role="presentation"
       >
         <button
-          class="_nav-item_eb2dec"
+          class="_nav-item_0471db"
           disabled=""
         >
           Disabled
         </button>
       </li>
       <li
-        class="_nav-tab_eb2dec"
+        class="_nav-tab_0471db"
         role="presentation"
       >
         <a
-          class="_nav-item_eb2dec"
+          class="_nav-item_0471db"
           href="https://example.com"
         >
           External
@@ -63,48 +63,48 @@ exports[`<NavBar /> > render a tabbed nav bar 1`] = `
 <div>
   <div>
     <nav
-      class="_nav-bar_eb2dec"
+      class="_nav-bar_0471db"
       role="presentation"
     >
       <ul
         aria-label="main"
-        class="_nav-bar-items_eb2dec"
+        class="_nav-bar-items_0471db"
         role="tablist"
       >
         <li
-          class="_nav-tab_eb2dec"
+          class="_nav-tab_0471db"
           role="presentation"
         >
           <button
             aria-controls="panel-1"
             aria-selected="false"
-            class="_nav-item_eb2dec"
+            class="_nav-item_0471db"
             role="tab"
           >
             Tab 1
           </button>
         </li>
         <li
-          class="_nav-tab_eb2dec"
+          class="_nav-tab_0471db"
           data-current="true"
           role="presentation"
         >
           <button
             aria-controls="panel-2"
             aria-selected="true"
-            class="_nav-item_eb2dec"
+            class="_nav-item_0471db"
             role="tab"
           >
             Tab 2
           </button>
         </li>
         <li
-          class="_nav-tab_eb2dec"
+          class="_nav-tab_0471db"
           role="presentation"
         >
           <button
             aria-controls="panel-3"
-            class="_nav-item_eb2dec"
+            class="_nav-item_0471db"
             disabled=""
             role="tab"
           >

--- a/src/components/Nav/__snapshots__/NavItem.test.tsx.snap
+++ b/src/components/Nav/__snapshots__/NavItem.test.tsx.snap
@@ -4,20 +4,20 @@ exports[`<NavItem /> > render a Active item 1`] = `
 <div>
   <nav
     aria-label="Testing"
-    class="_nav-bar_eb2dec"
+    class="_nav-bar_0471db"
     role="navigation"
   >
     <ul
-      class="_nav-bar-items_eb2dec"
+      class="_nav-bar-items_0471db"
     >
       <li
-        class="_nav-tab_eb2dec"
+        class="_nav-tab_0471db"
         data-current="true"
         role="presentation"
       >
         <button
           aria-current="true"
-          class="_nav-item_eb2dec"
+          class="_nav-item_0471db"
         >
           Sessions
         </button>
@@ -31,20 +31,20 @@ exports[`<NavItem /> > render a ActiveDisabled item 1`] = `
 <div>
   <nav
     aria-label="Testing"
-    class="_nav-bar_eb2dec"
+    class="_nav-bar_0471db"
     role="navigation"
   >
     <ul
-      class="_nav-bar-items_eb2dec"
+      class="_nav-bar-items_0471db"
     >
       <li
-        class="_nav-tab_eb2dec"
+        class="_nav-tab_0471db"
         data-current="true"
         role="presentation"
       >
         <button
           aria-current="true"
-          class="_nav-item_eb2dec"
+          class="_nav-item_0471db"
           disabled=""
         >
           Sessions
@@ -59,20 +59,20 @@ exports[`<NavItem /> > render a ActiveLink item 1`] = `
 <div>
   <nav
     aria-label="Testing"
-    class="_nav-bar_eb2dec"
+    class="_nav-bar_0471db"
     role="navigation"
   >
     <ul
-      class="_nav-bar-items_eb2dec"
+      class="_nav-bar-items_0471db"
     >
       <li
-        class="_nav-tab_eb2dec"
+        class="_nav-tab_0471db"
         data-current="true"
         role="presentation"
       >
         <a
           aria-current="true"
-          class="_nav-item_eb2dec"
+          class="_nav-item_0471db"
           href="https://example.org"
         >
           Sessions
@@ -87,18 +87,18 @@ exports[`<NavItem /> > render a Disabled item 1`] = `
 <div>
   <nav
     aria-label="Testing"
-    class="_nav-bar_eb2dec"
+    class="_nav-bar_0471db"
     role="navigation"
   >
     <ul
-      class="_nav-bar-items_eb2dec"
+      class="_nav-bar-items_0471db"
     >
       <li
-        class="_nav-tab_eb2dec"
+        class="_nav-tab_0471db"
         role="presentation"
       >
         <button
-          class="_nav-item_eb2dec"
+          class="_nav-item_0471db"
           disabled=""
         >
           Sessions
@@ -113,18 +113,18 @@ exports[`<NavItem /> > render a Link item 1`] = `
 <div>
   <nav
     aria-label="Testing"
-    class="_nav-bar_eb2dec"
+    class="_nav-bar_0471db"
     role="navigation"
   >
     <ul
-      class="_nav-bar-items_eb2dec"
+      class="_nav-bar-items_0471db"
     >
       <li
-        class="_nav-tab_eb2dec"
+        class="_nav-tab_0471db"
         role="presentation"
       >
         <a
-          class="_nav-item_eb2dec"
+          class="_nav-item_0471db"
           href="https://example.org"
         >
           Sessions
@@ -139,18 +139,18 @@ exports[`<NavItem /> > render a default item 1`] = `
 <div>
   <nav
     aria-label="Testing"
-    class="_nav-bar_eb2dec"
+    class="_nav-bar_0471db"
     role="navigation"
   >
     <ul
-      class="_nav-bar-items_eb2dec"
+      class="_nav-bar-items_0471db"
     >
       <li
-        class="_nav-tab_eb2dec"
+        class="_nav-tab_0471db"
         role="presentation"
       >
         <button
-          class="_nav-item_eb2dec"
+          class="_nav-item_0471db"
         >
           Sessions
         </button>

--- a/src/components/Progress/__snapshots__/Progress.test.tsx.snap
+++ b/src/components/Progress/__snapshots__/Progress.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`Progress > renders a green progress bar 1`] = `
 <div>
   <div
-    class="_progress-bar-container_e5fb97"
+    class="_progress-bar-container_a46e85"
     data-tint="green"
   >
     <div
-      class="_progress-bar-label_e5fb97"
+      class="_progress-bar-label_a46e85"
       id="«r5»"
     >
       Full progress bar
@@ -18,7 +18,7 @@ exports[`Progress > renders a green progress bar 1`] = `
       aria-valuemin="0"
       aria-valuenow="100"
       aria-valuetext="Full progress bar"
-      class="_progress-bar_e5fb97"
+      class="_progress-bar_a46e85"
       data-max="100"
       data-size="sm"
       data-state="complete"
@@ -26,7 +26,7 @@ exports[`Progress > renders a green progress bar 1`] = `
       role="progressbar"
     >
       <div
-        class="_progress-bar-indicator_e5fb97"
+        class="_progress-bar-indicator_a46e85"
         data-max="100"
         data-state="complete"
         data-value="100"
@@ -40,11 +40,11 @@ exports[`Progress > renders a green progress bar 1`] = `
 exports[`Progress > renders a large full progress bar 1`] = `
 <div>
   <div
-    class="_progress-bar-container_e5fb97"
+    class="_progress-bar-container_a46e85"
     data-tint="green"
   >
     <div
-      class="_progress-bar-label_e5fb97"
+      class="_progress-bar-label_a46e85"
       id="«r2»"
     >
       Full progress bar
@@ -55,7 +55,7 @@ exports[`Progress > renders a large full progress bar 1`] = `
       aria-valuemin="0"
       aria-valuenow="100"
       aria-valuetext="Full progress bar"
-      class="_progress-bar_e5fb97"
+      class="_progress-bar_a46e85"
       data-max="100"
       data-size="lg"
       data-state="complete"
@@ -63,7 +63,7 @@ exports[`Progress > renders a large full progress bar 1`] = `
       role="progressbar"
     >
       <div
-        class="_progress-bar-indicator_e5fb97"
+        class="_progress-bar-indicator_a46e85"
         data-max="100"
         data-state="complete"
         data-value="100"
@@ -77,11 +77,11 @@ exports[`Progress > renders a large full progress bar 1`] = `
 exports[`Progress > renders a large half progress bar 1`] = `
 <div>
   <div
-    class="_progress-bar-container_e5fb97"
+    class="_progress-bar-container_a46e85"
     data-tint="green"
   >
     <div
-      class="_progress-bar-label_e5fb97"
+      class="_progress-bar-label_a46e85"
       id="«r3»"
     >
       Half-full progress bar
@@ -92,7 +92,7 @@ exports[`Progress > renders a large half progress bar 1`] = `
       aria-valuemin="0"
       aria-valuenow="50"
       aria-valuetext="Half-full progress bar"
-      class="_progress-bar_e5fb97"
+      class="_progress-bar_a46e85"
       data-max="100"
       data-size="lg"
       data-state="loading"
@@ -100,7 +100,7 @@ exports[`Progress > renders a large half progress bar 1`] = `
       role="progressbar"
     >
       <div
-        class="_progress-bar-indicator_e5fb97"
+        class="_progress-bar-indicator_a46e85"
         data-max="100"
         data-state="loading"
         data-value="50"
@@ -114,11 +114,11 @@ exports[`Progress > renders a large half progress bar 1`] = `
 exports[`Progress > renders a lime progress bar 1`] = `
 <div>
   <div
-    class="_progress-bar-container_e5fb97"
+    class="_progress-bar-container_a46e85"
     data-tint="lime"
   >
     <div
-      class="_progress-bar-label_e5fb97"
+      class="_progress-bar-label_a46e85"
       id="«r7»"
     >
       Three-quarters full progress bar
@@ -129,7 +129,7 @@ exports[`Progress > renders a lime progress bar 1`] = `
       aria-valuemin="0"
       aria-valuenow="75"
       aria-valuetext="Three-quarters full progress bar"
-      class="_progress-bar_e5fb97"
+      class="_progress-bar_a46e85"
       data-max="100"
       data-size="sm"
       data-state="loading"
@@ -137,7 +137,7 @@ exports[`Progress > renders a lime progress bar 1`] = `
       role="progressbar"
     >
       <div
-        class="_progress-bar-indicator_e5fb97"
+        class="_progress-bar-indicator_a46e85"
         data-max="100"
         data-state="loading"
         data-value="75"
@@ -151,11 +151,11 @@ exports[`Progress > renders a lime progress bar 1`] = `
 exports[`Progress > renders a red progress bar 1`] = `
 <div>
   <div
-    class="_progress-bar-container_e5fb97"
+    class="_progress-bar-container_a46e85"
     data-tint="red"
   >
     <div
-      class="_progress-bar-label_e5fb97"
+      class="_progress-bar-label_a46e85"
       id="«r6»"
     >
       Quarter-full progress bar
@@ -166,7 +166,7 @@ exports[`Progress > renders a red progress bar 1`] = `
       aria-valuemin="0"
       aria-valuenow="25"
       aria-valuetext="Quarter-full progress bar"
-      class="_progress-bar_e5fb97"
+      class="_progress-bar_a46e85"
       data-max="100"
       data-size="sm"
       data-state="loading"
@@ -174,7 +174,7 @@ exports[`Progress > renders a red progress bar 1`] = `
       role="progressbar"
     >
       <div
-        class="_progress-bar-indicator_e5fb97"
+        class="_progress-bar-indicator_a46e85"
         data-max="100"
         data-state="loading"
         data-value="25"
@@ -188,11 +188,11 @@ exports[`Progress > renders a red progress bar 1`] = `
 exports[`Progress > renders a small full progress bar 1`] = `
 <div>
   <div
-    class="_progress-bar-container_e5fb97"
+    class="_progress-bar-container_a46e85"
     data-tint="green"
   >
     <div
-      class="_progress-bar-label_e5fb97"
+      class="_progress-bar-label_a46e85"
       id="«r0»"
     >
       Full progress bar
@@ -203,7 +203,7 @@ exports[`Progress > renders a small full progress bar 1`] = `
       aria-valuemin="0"
       aria-valuenow="100"
       aria-valuetext="Full progress bar"
-      class="_progress-bar_e5fb97"
+      class="_progress-bar_a46e85"
       data-max="100"
       data-size="sm"
       data-state="complete"
@@ -211,7 +211,7 @@ exports[`Progress > renders a small full progress bar 1`] = `
       role="progressbar"
     >
       <div
-        class="_progress-bar-indicator_e5fb97"
+        class="_progress-bar-indicator_a46e85"
         data-max="100"
         data-state="complete"
         data-value="100"
@@ -225,11 +225,11 @@ exports[`Progress > renders a small full progress bar 1`] = `
 exports[`Progress > renders a small half progress bar 1`] = `
 <div>
   <div
-    class="_progress-bar-container_e5fb97"
+    class="_progress-bar-container_a46e85"
     data-tint="green"
   >
     <div
-      class="_progress-bar-label_e5fb97"
+      class="_progress-bar-label_a46e85"
       id="«r1»"
     >
       Half-full progress bar
@@ -240,7 +240,7 @@ exports[`Progress > renders a small half progress bar 1`] = `
       aria-valuemin="0"
       aria-valuenow="50"
       aria-valuetext="Half-full progress bar"
-      class="_progress-bar_e5fb97"
+      class="_progress-bar_a46e85"
       data-max="100"
       data-size="sm"
       data-state="loading"
@@ -248,7 +248,7 @@ exports[`Progress > renders a small half progress bar 1`] = `
       role="progressbar"
     >
       <div
-        class="_progress-bar-indicator_e5fb97"
+        class="_progress-bar-indicator_a46e85"
         data-max="100"
         data-state="loading"
         data-value="50"
@@ -262,10 +262,10 @@ exports[`Progress > renders a small half progress bar 1`] = `
 exports[`Progress > renders an empty progress bar 1`] = `
 <div>
   <div
-    class="_progress-bar-container_e5fb97"
+    class="_progress-bar-container_a46e85"
   >
     <div
-      class="_progress-bar-label_e5fb97"
+      class="_progress-bar-label_a46e85"
       id="«r4»"
     >
       Empty progress bar
@@ -276,7 +276,7 @@ exports[`Progress > renders an empty progress bar 1`] = `
       aria-valuemin="0"
       aria-valuenow="0"
       aria-valuetext="Empty progress bar"
-      class="_progress-bar_e5fb97"
+      class="_progress-bar_a46e85"
       data-max="100"
       data-size="sm"
       data-state="loading"
@@ -284,7 +284,7 @@ exports[`Progress > renders an empty progress bar 1`] = `
       role="progressbar"
     >
       <div
-        class="_progress-bar-indicator_e5fb97"
+        class="_progress-bar-indicator_a46e85"
         data-max="100"
         data-state="loading"
         data-value="0"

--- a/src/components/ReleaseAnnouncement/__snapshots__/ReleaseAnnouncement.test.tsx.snap
+++ b/src/components/ReleaseAnnouncement/__snapshots__/ReleaseAnnouncement.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ReleaseAnnouncement > renders 1`] = `
 <div
   aria-describedby="«r1»"
   aria-labelledby="«r0»"
-  class="_content_219739"
+  class="_content_4b2dd5"
   data-floating-ui-focusable=""
   id="«r2»"
   role="dialog"
@@ -13,7 +13,7 @@ exports[`ReleaseAnnouncement > renders 1`] = `
 >
   <svg
     aria-hidden="true"
-    class="_arrow_219739"
+    class="_arrow_4b2dd5"
     height="20"
     style="position: absolute; pointer-events: none; right: calc(100% - 0px); transform: rotate(90deg); top: -1px;"
     viewBox="0 0 20 20"
@@ -35,19 +35,19 @@ exports[`ReleaseAnnouncement > renders 1`] = `
     </clippath>
   </svg>
   <h3
-    class="_typography_489030 _font-body-lg-semibold_489030 _header_219739"
+    class="_typography_61e060 _font-body-lg-semibold_61e060 _header_4b2dd5"
     id="«r0»"
   >
     Notifications have moved
   </h3>
   <span
-    class="_typography_489030 _font-body-sm-regular_489030 _description_219739"
+    class="_typography_61e060 _font-body-sm-regular_61e060 _description_4b2dd5"
     id="«r1»"
   >
     From now on, click the icon here to view your notifications.
   </span>
   <button
-    class="_button_2a1efe _button_219739"
+    class="_button_0829c1 _button_4b2dd5"
     data-kind="secondary"
     data-size="sm"
     role="button"
@@ -62,7 +62,7 @@ exports[`ReleaseAnnouncement > renders the component at the bottom of the trigge
 <div
   aria-describedby="«rd»"
   aria-labelledby="«rc»"
-  class="_content_219739"
+  class="_content_4b2dd5"
   data-floating-ui-focusable=""
   id="«re»"
   role="dialog"
@@ -71,7 +71,7 @@ exports[`ReleaseAnnouncement > renders the component at the bottom of the trigge
 >
   <svg
     aria-hidden="true"
-    class="_arrow_219739"
+    class="_arrow_4b2dd5"
     height="20"
     style="position: absolute; pointer-events: none; bottom: 100%; transform: rotate(180deg); left: -1px;"
     viewBox="0 0 20 20"
@@ -93,19 +93,19 @@ exports[`ReleaseAnnouncement > renders the component at the bottom of the trigge
     </clippath>
   </svg>
   <h3
-    class="_typography_489030 _font-body-lg-semibold_489030 _header_219739"
+    class="_typography_61e060 _font-body-lg-semibold_61e060 _header_4b2dd5"
     id="«rc»"
   >
     Notifications have moved
   </h3>
   <span
-    class="_typography_489030 _font-body-sm-regular_489030 _description_219739"
+    class="_typography_61e060 _font-body-sm-regular_61e060 _description_4b2dd5"
     id="«rd»"
   >
     From now on, click the icon here to view your notifications.
   </span>
   <button
-    class="_button_2a1efe _button_219739"
+    class="_button_0829c1 _button_4b2dd5"
     data-kind="secondary"
     data-size="sm"
     role="button"
@@ -120,7 +120,7 @@ exports[`ReleaseAnnouncement > renders with a long label header and description 
 <div
   aria-describedby="«r7»"
   aria-labelledby="«r6»"
-  class="_content_219739"
+  class="_content_4b2dd5"
   data-floating-ui-focusable=""
   id="«r8»"
   role="dialog"
@@ -129,7 +129,7 @@ exports[`ReleaseAnnouncement > renders with a long label header and description 
 >
   <svg
     aria-hidden="true"
-    class="_arrow_219739"
+    class="_arrow_4b2dd5"
     height="20"
     style="position: absolute; pointer-events: none; right: calc(100% - 0px); transform: rotate(90deg); top: -1px;"
     viewBox="0 0 20 20"
@@ -151,19 +151,19 @@ exports[`ReleaseAnnouncement > renders with a long label header and description 
     </clippath>
   </svg>
   <h3
-    class="_typography_489030 _font-body-lg-semibold_489030 _header_219739"
+    class="_typography_61e060 _font-body-lg-semibold_61e060 _header_4b2dd5"
     id="«r6»"
   >
     A multi line header which is taking multiple lines
   </h3>
   <span
-    class="_typography_489030 _font-body-sm-regular_489030 _description_219739"
+    class="_typography_61e060 _font-body-sm-regular_61e060 _description_4b2dd5"
     id="«r7»"
   >
     A multi line description which is taking multiple lines. The OK button should be vertically centred.
   </span>
   <button
-    class="_button_2a1efe _button_219739"
+    class="_button_0829c1 _button_4b2dd5"
     data-kind="secondary"
     data-size="sm"
     role="button"
@@ -178,7 +178,7 @@ exports[`ReleaseAnnouncement > renders without an arrow 1`] = `
 <div
   aria-describedby="«rn»"
   aria-labelledby="«rm»"
-  class="_content_219739"
+  class="_content_4b2dd5"
   data-floating-ui-focusable=""
   id="«ro»"
   role="dialog"
@@ -186,19 +186,19 @@ exports[`ReleaseAnnouncement > renders without an arrow 1`] = `
   tabindex="-1"
 >
   <h3
-    class="_typography_489030 _font-body-lg-semibold_489030 _header_219739"
+    class="_typography_61e060 _font-body-lg-semibold_61e060 _header_4b2dd5"
     id="«rm»"
   >
     Notifications have moved
   </h3>
   <span
-    class="_typography_489030 _font-body-sm-regular_489030 _description_219739"
+    class="_typography_61e060 _font-body-sm-regular_61e060 _description_4b2dd5"
     id="«rn»"
   >
     From now on, click the icon here to view your notifications.
   </span>
   <button
-    class="_button_2a1efe _button_219739"
+    class="_button_0829c1 _button_4b2dd5"
     data-kind="secondary"
     data-size="sm"
     role="button"

--- a/src/components/Search/__snapshots__/Search.test.tsx.snap
+++ b/src/components/Search/__snapshots__/Search.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`Search > renders 1`] = `
 <DocumentFragment>
   <form>
     <label
-      class="_label_dc87d2 _field_dc87d2 _search_a9d8a5"
+      class="_label_af3470 _field_af3470 _search_7f1f6b"
       for="«r0»"
     >
       <svg
-        class="_icon_a9d8a5"
+        class="_icon_7f1f6b"
         fill="currentColor"
         height="20"
         viewBox="0 0 24 24"
@@ -20,7 +20,7 @@ exports[`Search > renders 1`] = `
         />
       </svg>
       <input
-        class="_input_a9d8a5"
+        class="_input_7f1f6b"
         id="«r0»"
         name="search"
         placeholder="Search…"

--- a/src/components/Separator/__snapshots__/Separator.test.tsx.snap
+++ b/src/components/Separator/__snapshots__/Separator.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Separator > renders 1`] = `
 <DocumentFragment>
   <div
-    class="_separator_162edc"
+    class="_separator_59a6a1"
     data-kind="primary"
     data-orientation="horizontal"
     role="separator"

--- a/src/components/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/src/components/Toast/__snapshots__/Toast.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Toast > renders 1`] = `
 <DocumentFragment>
   <div
-    class="_toast-container_e9cea7"
+    class="_toast-container_78370f"
   />
 </DocumentFragment>
 `;

--- a/src/components/Typography/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/Typography/__snapshots__/Heading.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Heading > renders 1`] = `
 <DocumentFragment>
   <h1
-    class="_typography_489030 _font-heading-md-regular_489030"
+    class="_typography_61e060 _font-heading-md-regular_61e060"
   >
     The quick brown fox jumps over the lazy dog.
   </h1>

--- a/src/components/Typography/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Typography/__snapshots__/Text.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Body > renders 1`] = `
 <DocumentFragment>
   <p
-    class="_typography_489030 _font-body-md-regular_489030"
+    class="_typography_61e060 _font-body-md-regular_61e060"
   >
     The quick brown fox jumps over the lazy dog.
   </p>

--- a/src/components/VisualList/__snapshots__/VisualList.test.tsx.snap
+++ b/src/components/VisualList/__snapshots__/VisualList.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`VisualList > renders a Default VisualList 1`] = `
 <div>
   <ul
-    class="_visual-list_7f22f8"
+    class="_visual-list_04acb0"
   >
     <li
-      class="_visual-list-item_1553df"
+      class="_visual-list-item_f434f3"
     >
       <svg
         aria-hidden="true"
-        class="_visual-list-item-icon_1553df"
+        class="_visual-list-item-icon_f434f3"
         fill="currentColor"
         height="24px"
         viewBox="0 0 24 24"
@@ -29,11 +29,11 @@ exports[`VisualList > renders a Default VisualList 1`] = `
       First item
     </li>
     <li
-      class="_visual-list-item_1553df"
+      class="_visual-list-item_f434f3"
     >
       <svg
         aria-hidden="true"
-        class="_visual-list-item-icon_1553df"
+        class="_visual-list-item-icon_f434f3"
         fill="currentColor"
         height="24px"
         viewBox="0 0 24 24"
@@ -52,11 +52,11 @@ exports[`VisualList > renders a Default VisualList 1`] = `
       Second item
     </li>
     <li
-      class="_visual-list-item_1553df"
+      class="_visual-list-item_f434f3"
     >
       <svg
         aria-hidden="true"
-        class="_visual-list-item-icon_1553df"
+        class="_visual-list-item-icon_f434f3"
         fill="currentColor"
         height="24px"
         viewBox="0 0 24 24"

--- a/src/components/VisualList/__snapshots__/VisualListItem.test.tsx.snap
+++ b/src/components/VisualList/__snapshots__/VisualListItem.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`VisualListItem > renders a Default VisualListItem 1`] = `
 <div>
   <li
-    class="_visual-list-item_1553df"
+    class="_visual-list-item_f434f3"
   >
     <svg
       aria-hidden="true"
-      class="_visual-list-item-icon_1553df"
+      class="_visual-list-item-icon_f434f3"
       fill="currentColor"
       height="24px"
       viewBox="0 0 24 24"
@@ -31,11 +31,11 @@ exports[`VisualListItem > renders a Default VisualListItem 1`] = `
 exports[`VisualListItem > renders a Destructive VisualListItem 1`] = `
 <div>
   <li
-    class="_visual-list-item_1553df"
+    class="_visual-list-item_f434f3"
   >
     <svg
       aria-hidden="true"
-      class="_visual-list-item-icon_1553df _visual-list-item-icon-destructive_1553df"
+      class="_visual-list-item-icon_f434f3 _visual-list-item-icon-destructive_f434f3"
       fill="currentColor"
       height="24px"
       viewBox="0 0 24 24"
@@ -59,12 +59,12 @@ exports[`VisualListItem > renders a Destructive VisualListItem 1`] = `
 exports[`VisualListItem > renders a Multiline VisualListItem 1`] = `
 <div>
   <li
-    class="_visual-list-item_1553df"
+    class="_visual-list-item_f434f3"
     style="align-items: start;"
   >
     <svg
       aria-hidden="true"
-      class="_visual-list-item-icon_1553df"
+      class="_visual-list-item-icon_f434f3"
       fill="currentColor"
       height="24px"
       viewBox="0 0 24 24"
@@ -88,11 +88,11 @@ exports[`VisualListItem > renders a Multiline VisualListItem 1`] = `
 exports[`VisualListItem > renders a Success VisualListItem 1`] = `
 <div>
   <li
-    class="_visual-list-item_1553df"
+    class="_visual-list-item_f434f3"
   >
     <svg
       aria-hidden="true"
-      class="_visual-list-item-icon_1553df _visual-list-item-icon-success_1553df"
+      class="_visual-list-item-icon_f434f3 _visual-list-item-icon-success_f434f3"
       fill="currentColor"
       height="24px"
       viewBox="0 0 24 24"

--- a/src/utils/__ComponentTemplate__/__snapshots__/__ComponentTemplate__.test.tsx.snap
+++ b/src/utils/__ComponentTemplate__/__snapshots__/__ComponentTemplate__.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`__ComponentTemplate__ > renders 1`] = `
 <DocumentFragment>
   <div
-    class="_root_f6f11a"
+    class="_root_075f35"
   />
 </DocumentFragment>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,21 +82,21 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/core@^7.26.10":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.27.1.tgz#89de51e86bd12246003e3524704c49541b16c3e6"
-  integrity sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==
+"@babel/core@^7.27.4":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.28.0.tgz#55dad808d5bf3445a108eefc88ea3fdf034749a4"
+  integrity sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
     "@babel/code-frame" "^7.27.1"
-    "@babel/generator" "^7.27.1"
-    "@babel/helper-compilation-targets" "^7.27.1"
-    "@babel/helper-module-transforms" "^7.27.1"
-    "@babel/helpers" "^7.27.1"
-    "@babel/parser" "^7.27.1"
-    "@babel/template" "^7.27.1"
-    "@babel/traverse" "^7.27.1"
-    "@babel/types" "^7.27.1"
+    "@babel/generator" "^7.28.0"
+    "@babel/helper-compilation-targets" "^7.27.2"
+    "@babel/helper-module-transforms" "^7.27.3"
+    "@babel/helpers" "^7.27.6"
+    "@babel/parser" "^7.28.0"
+    "@babel/template" "^7.27.2"
+    "@babel/traverse" "^7.28.0"
+    "@babel/types" "^7.28.0"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -125,6 +125,17 @@
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^3.0.2"
 
+"@babel/generator@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.28.0.tgz#9cc2f7bd6eb054d77dc66c2664148a0c5118acd2"
+  integrity sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==
+  dependencies:
+    "@babel/parser" "^7.28.0"
+    "@babel/types" "^7.28.0"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
 "@babel/helper-compilation-targets@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz#55af025ce365be3cdc0c1c1e56c6af617ce88875"
@@ -136,7 +147,7 @@
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-compilation-targets@^7.27.1":
+"@babel/helper-compilation-targets@^7.27.2":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz#46a0f6efab808d51d29ce96858dd10ce8732733d"
   integrity sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==
@@ -146,6 +157,11 @@
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
+
+"@babel/helper-globals@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
+  integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
 
 "@babel/helper-module-imports@^7.25.9":
   version "7.25.9"
@@ -172,19 +188,19 @@
     "@babel/helper-validator-identifier" "^7.25.9"
     "@babel/traverse" "^7.25.9"
 
-"@babel/helper-module-transforms@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz#e1663b8b71d2de948da5c4fb2a20ca4f3ec27a6f"
-  integrity sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==
+"@babel/helper-module-transforms@^7.27.3":
+  version "7.27.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz#db0bbcfba5802f9ef7870705a7ef8788508ede02"
+  integrity sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==
   dependencies:
     "@babel/helper-module-imports" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
-    "@babel/traverse" "^7.27.1"
+    "@babel/traverse" "^7.27.3"
 
-"@babel/helper-plugin-utils@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz#9cbdd63a9443a2c92a725cca7ebca12cc8dd9f46"
-  integrity sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==
+"@babel/helper-plugin-utils@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz#ddb2f876534ff8013e6c2b299bf4d39b3c51d44c"
+  integrity sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==
 
 "@babel/helper-string-parser@^7.25.9":
   version "7.25.9"
@@ -224,13 +240,13 @@
     "@babel/template" "^7.25.9"
     "@babel/types" "^7.26.0"
 
-"@babel/helpers@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.27.1.tgz#ffc27013038607cdba3288e692c3611c06a18aa4"
-  integrity sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==
+"@babel/helpers@^7.27.6":
+  version "7.27.6"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.27.6.tgz#6456fed15b2cb669d2d1fabe84b66b34991d812c"
+  integrity sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==
   dependencies:
-    "@babel/template" "^7.27.1"
-    "@babel/types" "^7.27.1"
+    "@babel/template" "^7.27.2"
+    "@babel/types" "^7.27.6"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.25.3", "@babel/parser@^7.25.9", "@babel/parser@^7.26.0", "@babel/parser@^7.26.3":
   version "7.26.3"
@@ -253,19 +269,26 @@
   dependencies:
     "@babel/types" "^7.27.1"
 
-"@babel/plugin-transform-react-jsx-self@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.25.9.tgz#c0b6cae9c1b73967f7f9eb2fca9536ba2fad2858"
-  integrity sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==
+"@babel/parser@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.0.tgz#979829fbab51a29e13901e5a80713dbcb840825e"
+  integrity sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/types" "^7.28.0"
 
-"@babel/plugin-transform-react-jsx-source@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.25.9.tgz#4c6b8daa520b5f155b5fb55547d7c9fa91417503"
-  integrity sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==
+"@babel/plugin-transform-react-jsx-self@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz#af678d8506acf52c577cac73ff7fe6615c85fc92"
+  integrity sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-react-jsx-source@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz#dcfe2c24094bb757bf73960374e7c55e434f19f0"
+  integrity sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/runtime@^7.12.5":
   version "7.26.0"
@@ -283,7 +306,7 @@
     "@babel/parser" "^7.25.9"
     "@babel/types" "^7.25.9"
 
-"@babel/template@^7.27.1":
+"@babel/template@^7.27.1", "@babel/template@^7.27.2":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
   integrity sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==
@@ -318,6 +341,19 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
+"@babel/traverse@^7.27.3", "@babel/traverse@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.0.tgz#518aa113359b062042379e333db18380b537e34b"
+  integrity sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@babel/generator" "^7.28.0"
+    "@babel/helper-globals" "^7.28.0"
+    "@babel/parser" "^7.28.0"
+    "@babel/template" "^7.27.2"
+    "@babel/types" "^7.28.0"
+    debug "^4.3.1"
+
 "@babel/types@^7.0.0", "@babel/types@^7.18.9", "@babel/types@^7.20.7", "@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.26.3":
   version "7.26.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.3.tgz#37e79830f04c2b5687acc77db97fbc75fb81f3c0"
@@ -338,6 +374,14 @@
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.1.tgz#9defc53c16fc899e46941fc6901a9eea1c9d8560"
   integrity sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
+
+"@babel/types@^7.27.6", "@babel/types@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.0.tgz#2fd0159a6dc7353933920c43136335a9b264d950"
+  integrity sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
@@ -844,6 +888,14 @@
     magic-string "^0.30.0"
     react-docgen-typescript "^2.2.2"
 
+"@jridgewell/gen-mapping@^0.3.12":
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz#2234ce26c62889f03db3d7fea43c1932ab3e927b"
+  integrity sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
@@ -872,6 +924,14 @@
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.28":
+  version "0.3.29"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz#a58d31eaadaf92c6695680b2e1d464a9b8fbf7fc"
+  integrity sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -912,33 +972,33 @@
   dependencies:
     "@types/mdx" "^2.0.0"
 
-"@microsoft/api-extractor-model@7.30.1":
-  version "7.30.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.30.1.tgz#719e2ab8afe8fe3a5dd65aaa8783dbba90f7c802"
-  integrity sha512-CTS2PlASJHxVY8hqHORVb1HdECWOEMcMnM6/kDkPr0RZapAFSIHhg9D4jxuE8g+OWYHtPc10LCpmde5pylTRlA==
+"@microsoft/api-extractor-model@7.30.6":
+  version "7.30.6"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.30.6.tgz#cd9c434521dda3b226cc0f6aefb9c20afaf99c92"
+  integrity sha512-znmFn69wf/AIrwHya3fxX6uB5etSIn6vg4Q4RB/tb5VDDs1rqREc+AvMC/p19MUN13CZ7+V/8pkYPTj7q8tftg==
   dependencies:
     "@microsoft/tsdoc" "~0.15.1"
     "@microsoft/tsdoc-config" "~0.17.1"
-    "@rushstack/node-core-library" "5.10.1"
+    "@rushstack/node-core-library" "5.13.1"
 
-"@microsoft/api-extractor@^7.48.1":
-  version "7.48.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.48.1.tgz#792197cfc5113cd2efc04524c065d682ef58d2ba"
-  integrity sha512-HN9Osa1WxqLM66RaqB5nPAadx+nTIQmY/XtkFdaJvusjG8Tus++QqZtD7KPZDSkhEMGHsYeSyeU8qUzCDUXPjg==
+"@microsoft/api-extractor@^7.50.1":
+  version "7.52.8"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.52.8.tgz#7cc944f44ca1b1ad9d7272ab5d98e81987c1f8ca"
+  integrity sha512-cszYIcjiNscDoMB1CIKZ3My61+JOhpERGlGr54i6bocvGLrcL/wo9o+RNXMBrb7XgLtKaizZWUpqRduQuHQLdg==
   dependencies:
-    "@microsoft/api-extractor-model" "7.30.1"
+    "@microsoft/api-extractor-model" "7.30.6"
     "@microsoft/tsdoc" "~0.15.1"
     "@microsoft/tsdoc-config" "~0.17.1"
-    "@rushstack/node-core-library" "5.10.1"
+    "@rushstack/node-core-library" "5.13.1"
     "@rushstack/rig-package" "0.5.3"
-    "@rushstack/terminal" "0.14.4"
-    "@rushstack/ts-command-line" "4.23.2"
+    "@rushstack/terminal" "0.15.3"
+    "@rushstack/ts-command-line" "5.0.1"
     lodash "~4.17.15"
     minimatch "~3.0.3"
     resolve "~1.22.1"
     semver "~7.5.4"
     source-map "~0.6.1"
-    typescript "5.4.2"
+    typescript "5.8.2"
 
 "@microsoft/tsdoc-config@~0.17.1":
   version "0.17.1"
@@ -1322,10 +1382,10 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.0.tgz#f817d1d3265ac5415dadc67edab30ae196696438"
   integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
 
-"@rolldown/pluginutils@1.0.0-beta.9":
-  version "1.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz#68ef9fff5a9791a642cea0dc4380ce6cb487a84a"
-  integrity sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==
+"@rolldown/pluginutils@1.0.0-beta.19":
+  version "1.0.0-beta.19"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz#fc3b95145a8e7a3bf92754269d8e4f40eea8a244"
+  integrity sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==
 
 "@rollup/pluginutils@^5.0.2":
   version "5.1.3"
@@ -1345,115 +1405,115 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@rollup/rollup-android-arm-eabi@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.2.tgz#c228d00a41f0dbd6fb8b7ea819bbfbf1c1157a10"
-  integrity sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg==
+"@rollup/rollup-android-arm-eabi@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.2.tgz#6819b7f1e41a49af566f629a1556eaeea774d043"
+  integrity sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==
 
-"@rollup/rollup-android-arm64@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.2.tgz#e2b38d0c912169fd55d7e38d723aada208d37256"
-  integrity sha512-13unNoZ8NzUmnndhPTkWPWbX3vtHodYmy+I9kuLxN+F+l+x3LdVF7UCu8TWVMt1POHLh6oDHhnOA04n8oJZhBw==
+"@rollup/rollup-android-arm64@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.2.tgz#7bd5591af68c64a75be1779e2b20f187878daba9"
+  integrity sha512-Yt5MKrOosSbSaAK5Y4J+vSiID57sOvpBNBR6K7xAaQvk3MkcNVV0f9fE20T+41WYN8hDn6SGFlFrKudtx4EoxA==
 
-"@rollup/rollup-darwin-arm64@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.2.tgz#1fddb3690f2ae33df16d334c613377f05abe4878"
-  integrity sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==
+"@rollup/rollup-darwin-arm64@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.2.tgz#e216c333e448c67973386e46dbfe8e381aafb055"
+  integrity sha512-EsnFot9ZieM35YNA26nhbLTJBHD0jTwWpPwmRVDzjylQT6gkar+zenfb8mHxWpRrbn+WytRRjE0WKsfaxBkVUA==
 
-"@rollup/rollup-darwin-x64@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.2.tgz#818298d11c8109e1112590165142f14be24b396d"
-  integrity sha512-47N4hxa01a4x6XnJoskMKTS8XZ0CZMd8YTbINbi+w03A2w4j1RTlnGHOz/P0+Bg1LaVL6ufZyNprSg+fW5nYQQ==
+"@rollup/rollup-darwin-x64@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.2.tgz#202f80eea3acfe3f67496fedffa006a5f1ce7f5a"
+  integrity sha512-dv/t1t1RkCvJdWWxQ2lWOO+b7cMsVw5YFaS04oHpZRWehI1h0fV1gF4wgGCTyQHHjJDfbNpwOi6PXEafRBBezw==
 
-"@rollup/rollup-freebsd-arm64@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.2.tgz#91a28dc527d5bed7f9ecf0e054297b3012e19618"
-  integrity sha512-8t6aL4MD+rXSHHZUR1z19+9OFJ2rl1wGKvckN47XFRVO+QL/dUSpKA2SLRo4vMg7ELA8pzGpC+W9OEd1Z/ZqoQ==
+"@rollup/rollup-freebsd-arm64@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.2.tgz#4880f9769f1a7eec436b9c146e1d714338c26567"
+  integrity sha512-W4tt4BLorKND4qeHElxDoim0+BsprFTwb+vriVQnFFtT/P6v/xO5I99xvYnVzKWrK6j7Hb0yp3x7V5LUbaeOMg==
 
-"@rollup/rollup-freebsd-x64@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.2.tgz#28acadefa76b5c7bede1576e065b51d335c62c62"
-  integrity sha512-C+AyHBzfpsOEYRFjztcYUFsH4S7UsE9cDtHCtma5BK8+ydOZYgMmWg1d/4KBytQspJCld8ZIujFMAdKG1xyr4Q==
+"@rollup/rollup-freebsd-x64@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.2.tgz#647d6e333349b1c0fb322c2827ba1a53a0f10301"
+  integrity sha512-tdT1PHopokkuBVyHjvYehnIe20fxibxFCEhQP/96MDSOcyjM/shlTkZZLOufV3qO6/FQOSiJTBebhVc12JyPTA==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.2.tgz#819691464179cbcd9a9f9d3dc7617954840c6186"
-  integrity sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q==
+"@rollup/rollup-linux-arm-gnueabihf@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.2.tgz#7ba5c97a7224f49618861d093c4a7b40fa50867b"
+  integrity sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==
 
-"@rollup/rollup-linux-arm-musleabihf@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.2.tgz#d149207039e4189e267e8724050388effc80d704"
-  integrity sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg==
+"@rollup/rollup-linux-arm-musleabihf@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.2.tgz#f858dcf498299d6c625ec697a5191e0e41423905"
+  integrity sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==
 
-"@rollup/rollup-linux-arm64-gnu@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.2.tgz#fa72ebddb729c3c6d88973242f1a2153c83e86ec"
-  integrity sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg==
+"@rollup/rollup-linux-arm64-gnu@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.2.tgz#c0f1fc20c50666c61f574536a00cdd486b6aaae1"
+  integrity sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==
 
-"@rollup/rollup-linux-arm64-musl@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.2.tgz#2054216e34469ab8765588ebf343d531fc3c9228"
-  integrity sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg==
+"@rollup/rollup-linux-arm64-musl@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.2.tgz#0214efc3e404ddf108e946ad5f7e4ee2792a155a"
+  integrity sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==
 
-"@rollup/rollup-linux-loongarch64-gnu@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.2.tgz#818de242291841afbfc483a84f11e9c7a11959bc"
-  integrity sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw==
+"@rollup/rollup-linux-loongarch64-gnu@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.2.tgz#8303c4ea2ae7bcbb96b2c77cfb53527d964bfceb"
+  integrity sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==
 
-"@rollup/rollup-linux-powerpc64le-gnu@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.2.tgz#0bb4cb8fc4a2c635f68c1208c924b2145eb647cb"
-  integrity sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q==
+"@rollup/rollup-linux-powerpc64le-gnu@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.2.tgz#4197ffbc61809629094c0fccf825e43a40fbc0ca"
+  integrity sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==
 
-"@rollup/rollup-linux-riscv64-gnu@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.2.tgz#4b3b8e541b7b13e447ae07774217d98c06f6926d"
-  integrity sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg==
+"@rollup/rollup-linux-riscv64-gnu@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.2.tgz#bcb99c9004c9b91e3704a6a70c892cb0599b1f42"
+  integrity sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==
 
-"@rollup/rollup-linux-riscv64-musl@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.2.tgz#e065405e67d8bd64a7d0126c931bd9f03910817f"
-  integrity sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg==
+"@rollup/rollup-linux-riscv64-musl@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.2.tgz#3e943bae9b8b4637c573c1922392beb8a5e81acb"
+  integrity sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==
 
-"@rollup/rollup-linux-s390x-gnu@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.2.tgz#dda3265bbbfe16a5d0089168fd07f5ebb2a866fe"
-  integrity sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ==
+"@rollup/rollup-linux-s390x-gnu@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.2.tgz#dc43fb467bff9547f5b9937f38668da07fa8fa9f"
+  integrity sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==
 
-"@rollup/rollup-linux-x64-gnu@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.2.tgz#90993269b8b995b4067b7b9d72ff1c360ef90a17"
-  integrity sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==
+"@rollup/rollup-linux-x64-gnu@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.2.tgz#0699c560fa6ce6b846581a7e6c30c85c22a3f0da"
+  integrity sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==
 
-"@rollup/rollup-linux-x64-musl@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.2.tgz#fdf5b09fd121eb8d977ebb0fda142c7c0167b8de"
-  integrity sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA==
+"@rollup/rollup-linux-x64-musl@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.2.tgz#9fb1becedcdc9e227d4748576eb8ba2fad8d2e29"
+  integrity sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==
 
-"@rollup/rollup-win32-arm64-msvc@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.2.tgz#6397e1e012db64dfecfed0774cb9fcf89503d716"
-  integrity sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg==
+"@rollup/rollup-win32-arm64-msvc@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.2.tgz#fcf3e62edd76c560252b819f69627685f65887d7"
+  integrity sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==
 
-"@rollup/rollup-win32-ia32-msvc@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.2.tgz#df0991464a52a35506103fe18d29913bf8798a0c"
-  integrity sha512-dt1llVSGEsGKvzeIO76HToiYPNPYPkmjhMHhP00T9S4rDern8P2ZWvWAQUEJ+R1UdMWJ/42i/QqJ2WV765GZcA==
+"@rollup/rollup-win32-ia32-msvc@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.2.tgz#45a5304491d6da4666f6159be4f739d4d43a283f"
+  integrity sha512-+qMUrkbUurpE6DVRjiJCNGZBGo9xM4Y0FXU5cjgudWqIBWbcLkjE3XprJUsOFgC6xjBClwVa9k6O3A7K3vxb5Q==
 
-"@rollup/rollup-win32-x64-msvc@4.40.2":
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.2.tgz#8dae04d01a2cbd84d6297d99356674c6b993f0fc"
-  integrity sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA==
+"@rollup/rollup-win32-x64-msvc@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.2.tgz#660018c9696ad4f48abe8c5d56db53c81aadba25"
+  integrity sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==
 
-"@rushstack/node-core-library@5.10.1":
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-5.10.1.tgz#14c10c918ed12da003c21af9d5bf0e76633215d2"
-  integrity sha512-BSb/KcyBHmUQwINrgtzo6jiH0HlGFmrUy33vO6unmceuVKTEyL2q+P0fQq2oB5hvXVWOEUhxB2QvlkZluvUEmg==
+"@rushstack/node-core-library@5.13.1":
+  version "5.13.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-5.13.1.tgz#e56b915ecb08b5a92711acac6b233417353a32dc"
+  integrity sha512-5yXhzPFGEkVc9Fu92wsNJ9jlvdwz4RNb2bMso+/+TH0nMm1jDDDsOIf4l8GAkPxGuwPw5DH24RliWVfSPhlW/Q==
   dependencies:
     ajv "~8.13.0"
     ajv-draft-04 "~1.0.0"
     ajv-formats "~3.0.1"
-    fs-extra "~7.0.1"
+    fs-extra "~11.3.0"
     import-lazy "~4.0.0"
     jju "~1.4.0"
     resolve "~1.22.1"
@@ -1467,20 +1527,20 @@
     resolve "~1.22.1"
     strip-json-comments "~3.1.1"
 
-"@rushstack/terminal@0.14.4":
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/@rushstack/terminal/-/terminal-0.14.4.tgz#37e160b0878a324cf3e0fecab25fe48a030e29ed"
-  integrity sha512-NxACqERW0PHq8Rpq1V6v5iTHEwkRGxenjEW+VWqRYQ8T9puUzgmGHmEZUaUEDHAe9Qyvp0/Ew04sAiQw9XjhJg==
+"@rushstack/terminal@0.15.3":
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/@rushstack/terminal/-/terminal-0.15.3.tgz#365e0ae5ac73bb4883b096ae36c5011f52911861"
+  integrity sha512-DGJ0B2Vm69468kZCJkPj3AH5nN+nR9SPmC0rFHtzsS4lBQ7/dgOwtwVxYP7W9JPDMuRBkJ4KHmWKr036eJsj9g==
   dependencies:
-    "@rushstack/node-core-library" "5.10.1"
+    "@rushstack/node-core-library" "5.13.1"
     supports-color "~8.1.1"
 
-"@rushstack/ts-command-line@4.23.2":
-  version "4.23.2"
-  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.23.2.tgz#37b28a418db84d04f6a1c787390dd02ad8dfadf0"
-  integrity sha512-JJ7XZX5K3ThBBva38aomgsPv1L7FV6XmSOcR6HtM7HDFZJkepqT65imw26h9ggGqMjsY0R9jcl30tzKcVj9aOQ==
+"@rushstack/ts-command-line@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-5.0.1.tgz#e147394b5ce87ef79db95b5b4f155461d6f2c50e"
+  integrity sha512-bsbUucn41UXrQK7wgM8CNM/jagBytEyJqXw/umtI8d68vFm1Jwxh1OtLrlW7uGZgjCWiiPH6ooUNa1aVsuVr3Q==
   dependencies:
-    "@rushstack/terminal" "0.14.4"
+    "@rushstack/terminal" "0.15.3"
     "@types/argparse" "1.0.38"
     argparse "~1.0.9"
     string-argv "~0.3.1"
@@ -1731,10 +1791,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
-"@types/estree@1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
-  integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
+"@types/estree@1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
+  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
 "@types/json-schema@*":
   version "7.0.15"
@@ -1897,26 +1957,27 @@
   resolved "https://registry.yarnpkg.com/@vector-im/compound-design-tokens/-/compound-design-tokens-5.0.0.tgz#edacfa343fb58087cdfb18290e69d65ea631bf5d"
   integrity sha512-es63doHxQDOC8Mcf3pkbQA3wSJ9Gj1uPofcHCeU0EmbdLkb9cBRk5JJf5ZKmIj1+CAFoc81FF+COkYIcoGBuwA==
 
-"@vitejs/plugin-react@^4.0.4":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-4.5.1.tgz#19432712467ad3b81f24c85d695a6febf8d4cc11"
-  integrity sha512-uPZBqSI0YD4lpkIru6M35sIfylLGTyhGHvDZbNLuMA73lMlwJKz5xweH7FajfcCAc2HnINciejA9qTz0dr0M7A==
+"@vitejs/plugin-react@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-4.6.0.tgz#2707b485f44806d42d41c63921883cff9c54dfaa"
+  integrity sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ==
   dependencies:
-    "@babel/core" "^7.26.10"
-    "@babel/plugin-transform-react-jsx-self" "^7.25.9"
-    "@babel/plugin-transform-react-jsx-source" "^7.25.9"
-    "@rolldown/pluginutils" "1.0.0-beta.9"
+    "@babel/core" "^7.27.4"
+    "@babel/plugin-transform-react-jsx-self" "^7.27.1"
+    "@babel/plugin-transform-react-jsx-source" "^7.27.1"
+    "@rolldown/pluginutils" "1.0.0-beta.19"
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.17.0"
 
-"@vitest/coverage-v8@^3.0.0":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-3.1.3.tgz#d40e21d11384ef55d12ece1cb711b32930deb499"
-  integrity sha512-cj76U5gXCl3g88KSnf80kof6+6w+K4BjOflCl7t6yRJPDuCrHtVu0SgNYOUARJOL5TI8RScDbm5x4s1/P9bvpw==
+"@vitest/coverage-v8@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz#a2d8d040288c1956a1c7d0a0e2cdcfc7a3319f13"
+  integrity sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==
   dependencies:
     "@ampproject/remapping" "^2.3.0"
     "@bcoe/v8-coverage" "^1.0.2"
-    debug "^4.4.0"
+    ast-v8-to-istanbul "^0.3.3"
+    debug "^4.4.1"
     istanbul-lib-coverage "^3.2.2"
     istanbul-lib-report "^3.0.1"
     istanbul-lib-source-maps "^5.0.6"
@@ -1925,16 +1986,6 @@
     magicast "^0.3.5"
     std-env "^3.9.0"
     test-exclude "^7.0.1"
-    tinyrainbow "^2.0.0"
-
-"@vitest/expect@3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.1.3.tgz#bbca175cd2f23d7de9448a215baed8f3d7abd7b7"
-  integrity sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg==
-  dependencies:
-    "@vitest/spy" "3.1.3"
-    "@vitest/utils" "3.1.3"
-    chai "^5.2.0"
     tinyrainbow "^2.0.0"
 
 "@vitest/expect@3.2.4":
@@ -1948,52 +1999,39 @@
     chai "^5.2.0"
     tinyrainbow "^2.0.0"
 
-"@vitest/mocker@3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.1.3.tgz#121d0f2fcca20c9ccada9e2d6e761f7fc687f4ce"
-  integrity sha512-PJbLjonJK82uCWHjzgBJZuR7zmAOrSvKk1QBxrennDIgtH4uK0TB1PvYmc0XBCigxxtiAVPfWtAdy4lpz8SQGQ==
+"@vitest/mocker@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.2.4.tgz#4471c4efbd62db0d4fa203e65cc6b058a85cabd3"
+  integrity sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==
   dependencies:
-    "@vitest/spy" "3.1.3"
+    "@vitest/spy" "3.2.4"
     estree-walker "^3.0.3"
     magic-string "^0.30.17"
 
-"@vitest/pretty-format@3.1.3", "@vitest/pretty-format@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.1.3.tgz#760b9eab5f253d7d2e7dcd28ef34570f584023d4"
-  integrity sha512-i6FDiBeJUGLDKADw2Gb01UtUNb12yyXAqC/mmRWuYl+m/U9GS7s8us5ONmGkGpUUo7/iAYzI2ePVfOZTYvUifA==
-  dependencies:
-    tinyrainbow "^2.0.0"
-
-"@vitest/pretty-format@3.2.4":
+"@vitest/pretty-format@3.2.4", "@vitest/pretty-format@^3.2.4":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.4.tgz#3c102f79e82b204a26c7a5921bf47d534919d3b4"
   integrity sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==
   dependencies:
     tinyrainbow "^2.0.0"
 
-"@vitest/runner@3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.1.3.tgz#b268fa90fca38fab363f1107f057c0a2a141ee45"
-  integrity sha512-Tae+ogtlNfFei5DggOsSUvkIaSuVywujMj6HzR97AHK6XK8i3BuVyIifWAm/sE3a15lF5RH9yQIrbXYuo0IFyA==
+"@vitest/runner@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.2.4.tgz#5ce0274f24a971f6500f6fc166d53d8382430766"
+  integrity sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==
   dependencies:
-    "@vitest/utils" "3.1.3"
+    "@vitest/utils" "3.2.4"
     pathe "^2.0.3"
+    strip-literal "^3.0.0"
 
-"@vitest/snapshot@3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.1.3.tgz#39a8f9f8c6ba732ffde59adeacf0a549bef11e76"
-  integrity sha512-XVa5OPNTYUsyqG9skuUkFzAeFnEzDp8hQu7kZ0N25B1+6KjGm4hWLtURyBbsIAOekfWQ7Wuz/N/XXzgYO3deWQ==
+"@vitest/snapshot@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.2.4.tgz#40a8bc0346ac0aee923c0eefc2dc005d90bc987c"
+  integrity sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==
   dependencies:
-    "@vitest/pretty-format" "3.1.3"
+    "@vitest/pretty-format" "3.2.4"
     magic-string "^0.30.17"
     pathe "^2.0.3"
-
-"@vitest/spy@3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.1.3.tgz#ca81e2b4f0c3d6c75f35defa77c3336f39c8f605"
-  integrity sha512-x6w+ctOEmEXdWaa6TO4ilb7l9DxPR5bwEb6hILKuxfU1NqWT2mpJD9NJN7t3OTfxmVlOMrvtoFJGdgyzZ605lQ==
-  dependencies:
-    tinyspy "^3.0.2"
 
 "@vitest/spy@3.2.4":
   version "3.2.4"
@@ -2001,15 +2039,6 @@
   integrity sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==
   dependencies:
     tinyspy "^4.0.3"
-
-"@vitest/utils@3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.1.3.tgz#4f31bdfd646cd82d30bfa730d7410cb59d529669"
-  integrity sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==
-  dependencies:
-    "@vitest/pretty-format" "3.1.3"
-    loupe "^3.1.3"
-    tinyrainbow "^2.0.0"
 
 "@vitest/utils@3.2.4":
   version "3.2.4"
@@ -2020,17 +2049,29 @@
     loupe "^3.1.4"
     tinyrainbow "^2.0.0"
 
-"@volar/language-core@2.4.11", "@volar/language-core@~2.4.8":
+"@volar/language-core@2.4.11":
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/@volar/language-core/-/language-core-2.4.11.tgz#d95a9ec4f14fbdb41a6a64f9f321d11d23a5291c"
   integrity sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==
   dependencies:
     "@volar/source-map" "2.4.11"
 
+"@volar/language-core@~2.4.11":
+  version "2.4.18"
+  resolved "https://registry.yarnpkg.com/@volar/language-core/-/language-core-2.4.18.tgz#f409d984538908a91c65ab933587ef148cb7c11e"
+  integrity sha512-G3yYV85ekH4TV0EDS6DsS/dUJWrz675H9UgsxFz5pQbmas51a0Q2fF6Lb2q4RKgytuLZ4E0MBdT5PlVsJXNalw==
+  dependencies:
+    "@volar/source-map" "2.4.18"
+
 "@volar/source-map@2.4.11":
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-2.4.11.tgz#5876d4531508129724c2755e295db1df98bd5895"
   integrity sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==
+
+"@volar/source-map@2.4.18":
+  version "2.4.18"
+  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-2.4.18.tgz#4723e6436cc79d19bf85d9896c41597baecb79c6"
+  integrity sha512-zaj2V/zo/CHQ/xA75h60jBPgrz+Ou9s6aPl7dX0rT46/uill9aB/ZaDk92ROpJsa/9e2xftCeNAU9ZwVyB/egQ==
 
 "@volar/typescript@^2.4.11":
   version "2.4.11"
@@ -2068,16 +2109,16 @@
     de-indent "^1.0.2"
     he "^1.2.0"
 
-"@vue/language-core@2.1.10":
-  version "2.1.10"
-  resolved "https://registry.yarnpkg.com/@vue/language-core/-/language-core-2.1.10.tgz#5988e9ea155f3e09ccbbb3b2a0ddd530dad912e6"
-  integrity sha512-DAI289d0K3AB5TUG3xDp9OuQ71CnrujQwJrQnfuZDwo6eGNf0UoRlPuaVNO+Zrn65PC3j0oB2i7mNmVPggeGeQ==
+"@vue/language-core@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@vue/language-core/-/language-core-2.2.0.tgz#e48c54584f889f78b120ce10a050dfb316c7fcdf"
+  integrity sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==
   dependencies:
-    "@volar/language-core" "~2.4.8"
+    "@volar/language-core" "~2.4.11"
     "@vue/compiler-dom" "^3.5.0"
     "@vue/compiler-vue2" "^2.7.16"
     "@vue/shared" "^3.5.0"
-    alien-signals "^0.2.0"
+    alien-signals "^0.4.9"
     minimatch "^9.0.3"
     muggle-string "^0.4.1"
     path-browserify "^1.0.1"
@@ -2186,10 +2227,10 @@ ajv@~8.13.0:
     require-from-string "^2.0.2"
     uri-js "^4.4.1"
 
-alien-signals@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/alien-signals/-/alien-signals-0.2.2.tgz#439d09b363dc4d609c0f6ce69362dce068d23197"
-  integrity sha512-cZIRkbERILsBOXTQmMrxc9hgpxglstn69zm+F1ARf4aPAzdAFYd6sBq87ErO0Fj3DV94tglcyHG5kQz9nDC/8A==
+alien-signals@^0.4.9:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/alien-signals/-/alien-signals-0.4.14.tgz#9ff8f72a272300a51692f54bd9bbbada78fbf539"
+  integrity sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==
 
 ansi-align@^3.0.1:
   version "3.0.1"
@@ -2391,6 +2432,15 @@ ast-types@^0.16.1:
   integrity sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==
   dependencies:
     tslib "^2.0.1"
+
+ast-v8-to-istanbul@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.3.tgz#697101c116cff6b51c0e668ba6352e7e41fe8dd5"
+  integrity sha512-MuXMrSLVVoA6sYN/6Hke18vMzrT4TZNbZIj/hvh0fnYFpO+/kFXcLIaiPwXXWaQUPg4yJD8fj+lfJ7/1EBconw==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.25"
+    estree-walker "^3.0.3"
+    js-tokens "^9.0.1"
 
 astral-regex@^2.0.0:
   version "2.0.0"
@@ -2809,6 +2859,11 @@ confbox@^0.1.8:
   resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.1.8.tgz#820d73d3b3c82d9bd910652c5d4d599ef8ff8b06"
   integrity sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==
 
+confbox@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.2.2.tgz#8652f53961c74d9e081784beed78555974a9c110"
+  integrity sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==
+
 content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
@@ -2977,10 +3032,10 @@ debug@^4.4.1:
   dependencies:
     ms "^2.1.3"
 
-decimal.js@^10.4.3:
-  version "10.4.3"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
-  integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
+decimal.js@^10.5.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
 
 deep-eql@^5.0.1:
   version "5.0.2"
@@ -3547,6 +3602,11 @@ expect-type@^1.2.1:
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.1.tgz#af76d8b357cf5fa76c41c09dafb79c549e75f71f"
   integrity sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==
 
+exsolve@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/exsolve/-/exsolve-1.0.7.tgz#3b74e4c7ca5c5f9a19c3626ca857309fa99f9e9e"
+  integrity sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3615,6 +3675,11 @@ fdir@^6.4.4:
   version "6.4.4"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.4.tgz#1cfcf86f875a883e19a8fab53622cfe992e8d2f9"
   integrity sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==
+
+fdir@^6.4.6:
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.6.tgz#2b268c0232697063111bbf3f64810a2a741ba281"
+  integrity sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==
 
 file-entry-cache@^10.0.5:
   version "10.0.5"
@@ -3721,28 +3786,19 @@ form-data@^4.0.0:
     hasown "^2.0.2"
     mime-types "^2.1.12"
 
-form-data@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.1.tgz#ba1076daaaa5bfd7e99c1a6cb02aa0a5cff90d48"
-  integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@~7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+fs-extra@~11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
+  integrity sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==
   dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -3959,7 +4015,7 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -4443,6 +4499,11 @@ jju@~1.4.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-tokens@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.1.tgz#2ec43964658435296f6761b34e10671c2d9527f4"
+  integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
+
 js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
@@ -4450,15 +4511,14 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsdom@^26.0.0:
-  version "26.0.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-26.0.0.tgz#446dd1ad8cfc50df7e714e58f1f972c1763b354c"
-  integrity sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==
+jsdom@^26.1.0:
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-26.1.0.tgz#ab5f1c1cafc04bd878725490974ea5e8bf0c72b3"
+  integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
   dependencies:
     cssstyle "^4.2.1"
     data-urls "^5.0.0"
-    decimal.js "^10.4.3"
-    form-data "^4.0.1"
+    decimal.js "^10.5.0"
     html-encoding-sniffer "^4.0.0"
     http-proxy-agent "^7.0.2"
     https-proxy-agent "^7.0.6"
@@ -4468,12 +4528,12 @@ jsdom@^26.0.0:
     rrweb-cssom "^0.8.0"
     saxes "^6.0.0"
     symbol-tree "^3.2.4"
-    tough-cookie "^5.0.0"
+    tough-cookie "^5.1.1"
     w3c-xmlserializer "^5.0.0"
     webidl-conversions "^7.0.0"
     whatwg-encoding "^3.1.1"
     whatwg-mimetype "^4.0.0"
-    whatwg-url "^14.1.0"
+    whatwg-url "^14.1.1"
     ws "^8.18.0"
     xml-name-validator "^5.0.0"
 
@@ -4512,10 +4572,12 @@ json5@^2.2.2, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -4603,13 +4665,14 @@ lit@^2.1.3:
     lit-element "^3.3.0"
     lit-html "^2.8.0"
 
-local-pkg@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.5.1.tgz#69658638d2a95287534d4c2fff757980100dbb6d"
-  integrity sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==
+local-pkg@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-1.1.1.tgz#f5fe74a97a3bd3c165788ee08ca9fbe998dc58dd"
+  integrity sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==
   dependencies:
-    mlly "^1.7.3"
-    pkg-types "^1.2.1"
+    mlly "^1.7.4"
+    pkg-types "^2.0.1"
+    quansync "^0.2.8"
 
 locate-path@^6.0.0:
   version "6.0.0"
@@ -4662,7 +4725,7 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-loupe@^3.1.0, loupe@^3.1.3:
+loupe@^3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.3.tgz#042a8f7986d77f3d0f98ef7990a2b2fef18b0fd2"
   integrity sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==
@@ -4882,14 +4945,14 @@ mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mlly@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.7.3.tgz#d86c0fcd8ad8e16395eb764a5f4b831590cee48c"
-  integrity sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==
+mlly@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.7.4.tgz#3d7295ea2358ec7a271eaa5d000a0f84febe100f"
+  integrity sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==
   dependencies:
     acorn "^8.14.0"
-    pathe "^1.1.2"
-    pkg-types "^1.2.1"
+    pathe "^2.0.1"
+    pkg-types "^1.3.0"
     ufo "^1.5.4"
 
 ms@2.0.0:
@@ -4912,15 +4975,15 @@ nan@^2.19.0, nan@^2.20.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.2.tgz#6b504fd029fb8f38c0990e52ad5c26772fdacfbb"
   integrity sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==
 
+nanoid@^3.3.11:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
 nanoid@^3.3.7:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
   integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
-
-nanoid@^3.3.8:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -5177,12 +5240,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pathe@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
-  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
-
-pathe@^2.0.3:
+pathe@^2.0.1, pathe@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
@@ -5207,14 +5265,23 @@ picomatch@^4.0.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
-pkg-types@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.3.0.tgz#53d915eb99485798c554ad8eb2dc2af7c03006eb"
-  integrity sha512-kS7yWjVFCkIw9hqdJBoMxDdzEngmkr5FXeWZZfQ6GoYacjVnsW6l2CcYW/0ThD0vF4LPJgVYnrg4d0uuhwYQbg==
+pkg-types@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.3.1.tgz#bd7cc70881192777eef5326c19deb46e890917df"
+  integrity sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==
   dependencies:
     confbox "^0.1.8"
-    mlly "^1.7.3"
-    pathe "^1.1.2"
+    mlly "^1.7.4"
+    pathe "^2.0.1"
+
+pkg-types@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-2.2.0.tgz#049bf404f82a66c465200149457acf0c5fb0fb2d"
+  integrity sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==
+  dependencies:
+    confbox "^0.2.2"
+    exsolve "^1.0.7"
+    pathe "^2.0.3"
 
 playwright-core@1.49.1:
   version "1.49.1"
@@ -5267,12 +5334,12 @@ postcss@^8.4.49:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
-postcss@^8.5.3:
-  version "8.5.3"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.3.tgz#1463b6f1c7fb16fe258736cba29a2de35237eafb"
-  integrity sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==
+postcss@^8.5.6:
+  version "8.5.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
+  integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
   dependencies:
-    nanoid "^3.3.8"
+    nanoid "^3.3.11"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -5372,6 +5439,11 @@ punycode@^2.1.0, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+quansync@^0.2.8:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/quansync/-/quansync-0.2.10.tgz#32053cf166fa36511aae95fc49796116f2dc20e1"
+  integrity sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -5648,33 +5720,33 @@ rimraf@^6.0.0:
     glob "^11.0.0"
     package-json-from-dist "^1.0.0"
 
-rollup@^4.34.9:
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.40.2.tgz#778e88b7a197542682b3e318581f7697f55f0619"
-  integrity sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==
+rollup@^4.40.0:
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.44.2.tgz#faedb27cb2aa6742530c39668092eecbaf78c488"
+  integrity sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==
   dependencies:
-    "@types/estree" "1.0.7"
+    "@types/estree" "1.0.8"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.40.2"
-    "@rollup/rollup-android-arm64" "4.40.2"
-    "@rollup/rollup-darwin-arm64" "4.40.2"
-    "@rollup/rollup-darwin-x64" "4.40.2"
-    "@rollup/rollup-freebsd-arm64" "4.40.2"
-    "@rollup/rollup-freebsd-x64" "4.40.2"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.40.2"
-    "@rollup/rollup-linux-arm-musleabihf" "4.40.2"
-    "@rollup/rollup-linux-arm64-gnu" "4.40.2"
-    "@rollup/rollup-linux-arm64-musl" "4.40.2"
-    "@rollup/rollup-linux-loongarch64-gnu" "4.40.2"
-    "@rollup/rollup-linux-powerpc64le-gnu" "4.40.2"
-    "@rollup/rollup-linux-riscv64-gnu" "4.40.2"
-    "@rollup/rollup-linux-riscv64-musl" "4.40.2"
-    "@rollup/rollup-linux-s390x-gnu" "4.40.2"
-    "@rollup/rollup-linux-x64-gnu" "4.40.2"
-    "@rollup/rollup-linux-x64-musl" "4.40.2"
-    "@rollup/rollup-win32-arm64-msvc" "4.40.2"
-    "@rollup/rollup-win32-ia32-msvc" "4.40.2"
-    "@rollup/rollup-win32-x64-msvc" "4.40.2"
+    "@rollup/rollup-android-arm-eabi" "4.44.2"
+    "@rollup/rollup-android-arm64" "4.44.2"
+    "@rollup/rollup-darwin-arm64" "4.44.2"
+    "@rollup/rollup-darwin-x64" "4.44.2"
+    "@rollup/rollup-freebsd-arm64" "4.44.2"
+    "@rollup/rollup-freebsd-x64" "4.44.2"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.44.2"
+    "@rollup/rollup-linux-arm-musleabihf" "4.44.2"
+    "@rollup/rollup-linux-arm64-gnu" "4.44.2"
+    "@rollup/rollup-linux-arm64-musl" "4.44.2"
+    "@rollup/rollup-linux-loongarch64-gnu" "4.44.2"
+    "@rollup/rollup-linux-powerpc64le-gnu" "4.44.2"
+    "@rollup/rollup-linux-riscv64-gnu" "4.44.2"
+    "@rollup/rollup-linux-riscv64-musl" "4.44.2"
+    "@rollup/rollup-linux-s390x-gnu" "4.44.2"
+    "@rollup/rollup-linux-x64-gnu" "4.44.2"
+    "@rollup/rollup-linux-x64-musl" "4.44.2"
+    "@rollup/rollup-win32-arm64-msvc" "4.44.2"
+    "@rollup/rollup-win32-ia32-msvc" "4.44.2"
+    "@rollup/rollup-win32-x64-msvc" "4.44.2"
     fsevents "~2.3.2"
 
 rrweb-cssom@^0.8.0:
@@ -6139,6 +6211,13 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+strip-literal@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-3.0.0.tgz#ce9c452a91a0af2876ed1ae4e583539a353df3fc"
+  integrity sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==
+  dependencies:
+    js-tokens "^9.0.1"
+
 stylelint-config-recommended@^15.0.0:
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-15.0.0.tgz#93d48db401215708b724f078533864e52085a07b"
@@ -6372,28 +6451,23 @@ tinyexec@^0.3.2:
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
-tinyglobby@^0.2.13:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.13.tgz#a0e46515ce6cbcd65331537e57484af5a7b2ff7e"
-  integrity sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==
+tinyglobby@^0.2.14:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.14.tgz#5280b0cf3f972b050e74ae88406c0a6a58f4079d"
+  integrity sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==
   dependencies:
     fdir "^6.4.4"
     picomatch "^4.0.2"
 
-tinypool@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.0.2.tgz#706193cc532f4c100f66aa00b01c42173d9051b2"
-  integrity sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==
+tinypool@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
 
 tinyrainbow@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
   integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
-
-tinyspy@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
-  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
 
 tinyspy@^4.0.3:
   version "4.0.3"
@@ -6424,10 +6498,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.0.0.tgz#6b6518e2b5c070cf742d872ee0f4f92d69eac1af"
-  integrity sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==
+tough-cookie@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.2.tgz#66d774b4a1d9e12dc75089725af3ac75ec31bed7"
+  integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
   dependencies:
     tldts "^6.1.32"
 
@@ -6435,6 +6509,13 @@ tr46@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.0.0.tgz#3b46d583613ec7283020d79019f1335723801cec"
   integrity sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==
+  dependencies:
+    punycode "^2.3.1"
+
+tr46@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.1.1.tgz#96ae867cddb8fdb64a49cc3059a8d428bcf238ca"
+  integrity sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==
   dependencies:
     punycode "^2.3.1"
 
@@ -6534,10 +6615,10 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
-typescript@5.4.2:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
-  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
+typescript@5.8.2:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
+  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
 typescript@^5.2.2:
   version "5.7.2"
@@ -6584,10 +6665,10 @@ unicorn-magic@^0.1.0:
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
   integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
 
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
 unplugin@^1.3.1:
   version "1.16.0"
@@ -6657,71 +6738,73 @@ vaul@^1.0.0:
   dependencies:
     "@radix-ui/react-dialog" "^1.1.1"
 
-vite-node@3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.1.3.tgz#d021ced40b5a057305eaea9ce62c610c33b60a48"
-  integrity sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==
+vite-node@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.2.4.tgz#f3676d94c4af1e76898c162c92728bca65f7bb07"
+  integrity sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==
   dependencies:
     cac "^6.7.14"
-    debug "^4.4.0"
+    debug "^4.4.1"
     es-module-lexer "^1.7.0"
     pathe "^2.0.3"
-    vite "^5.0.0 || ^6.0.0"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
 
-vite-plugin-dts@^4.0.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/vite-plugin-dts/-/vite-plugin-dts-4.4.0.tgz#ef79b5ceaa39a70aa69b619b249b6b49be911257"
-  integrity sha512-CJ6phvnnPLF+aFk8Jz2ZcMBLleJ4gKJOXb9We5Kzmsp5bPuD+uMDeVefjFNYSXZ+wdcqnf+Yp2P7oA5hBKQTlQ==
+vite-plugin-dts@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz#51b60aaaa760d9cf5c2bb3676c69d81910d6b08c"
+  integrity sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==
   dependencies:
-    "@microsoft/api-extractor" "^7.48.1"
+    "@microsoft/api-extractor" "^7.50.1"
     "@rollup/pluginutils" "^5.1.4"
     "@volar/typescript" "^2.4.11"
-    "@vue/language-core" "2.1.10"
+    "@vue/language-core" "2.2.0"
     compare-versions "^6.1.1"
     debug "^4.4.0"
     kolorist "^1.8.0"
-    local-pkg "^0.5.1"
+    local-pkg "^1.0.0"
     magic-string "^0.30.17"
 
-"vite@^5.0.0 || ^6.0.0", vite@^6.0.0:
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-6.3.5.tgz#fec73879013c9c0128c8d284504c6d19410d12a3"
-  integrity sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==
+"vite@^5.0.0 || ^6.0.0 || ^7.0.0-0", vite@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.0.3.tgz#3bf15e1a6d054960406a70fa1052043938b39c5a"
+  integrity sha512-y2L5oJZF7bj4c0jgGYgBNSdIu+5HF+m68rn2cQXFbGoShdhV1phX9rbnxy9YXj82aS8MMsCLAAFkRxZeWdldrQ==
   dependencies:
     esbuild "^0.25.0"
-    fdir "^6.4.4"
+    fdir "^6.4.6"
     picomatch "^4.0.2"
-    postcss "^8.5.3"
-    rollup "^4.34.9"
-    tinyglobby "^0.2.13"
+    postcss "^8.5.6"
+    rollup "^4.40.0"
+    tinyglobby "^0.2.14"
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest@^3.0.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.1.3.tgz#0b0b01932408cd3af61867f4468d28bd83406ffb"
-  integrity sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==
+vitest@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.2.4.tgz#0637b903ad79d1539a25bc34c0ed54b5c67702ea"
+  integrity sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==
   dependencies:
-    "@vitest/expect" "3.1.3"
-    "@vitest/mocker" "3.1.3"
-    "@vitest/pretty-format" "^3.1.3"
-    "@vitest/runner" "3.1.3"
-    "@vitest/snapshot" "3.1.3"
-    "@vitest/spy" "3.1.3"
-    "@vitest/utils" "3.1.3"
+    "@types/chai" "^5.2.2"
+    "@vitest/expect" "3.2.4"
+    "@vitest/mocker" "3.2.4"
+    "@vitest/pretty-format" "^3.2.4"
+    "@vitest/runner" "3.2.4"
+    "@vitest/snapshot" "3.2.4"
+    "@vitest/spy" "3.2.4"
+    "@vitest/utils" "3.2.4"
     chai "^5.2.0"
-    debug "^4.4.0"
+    debug "^4.4.1"
     expect-type "^1.2.1"
     magic-string "^0.30.17"
     pathe "^2.0.3"
+    picomatch "^4.0.2"
     std-env "^3.9.0"
     tinybench "^2.9.0"
     tinyexec "^0.3.2"
-    tinyglobby "^0.2.13"
-    tinypool "^1.0.2"
+    tinyglobby "^0.2.14"
+    tinypool "^1.1.1"
     tinyrainbow "^2.0.0"
-    vite "^5.0.0 || ^6.0.0"
-    vite-node "3.1.3"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    vite-node "3.2.4"
     why-is-node-running "^2.3.0"
 
 vscode-uri@^3.0.8:
@@ -6766,12 +6849,12 @@ whatwg-url@^14.0.0:
     tr46 "^5.0.0"
     webidl-conversions "^7.0.0"
 
-whatwg-url@^14.1.0:
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.1.0.tgz#fffebec86cc8e6c2a657e50dc606207b870f0ab3"
-  integrity sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==
+whatwg-url@^14.1.1:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.2.0.tgz#4ee02d5d725155dae004f6ae95c73e7ef5d95663"
+  integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
   dependencies:
-    tr46 "^5.0.0"
+    tr46 "^5.1.0"
     webidl-conversions "^7.0.0"
 
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:


### PR DESCRIPTION
This is bumping vite & related packages. The diff in the snapshots is I think because Vite uses a new hash algorithm for CSS modules hashes?

Should make #305 easier

Replaces #357 