### PR TITLE
Fix the CSS export declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js",
+      "style": "./dist/style.css",
       "types": "./dist/index.d.ts",
-      "style": "./dist/style.css"
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
     },
     "./dist/style.css": "./dist/style.css"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       // This makes sure to keep the file structure in the output `dist` folder
       // the same as the input `src` folder
       fileName: "[name]",
-      cssFileName: "style.css",
+      cssFileName: "style", // Vite adds a `.css` suffix to the file name
     },
 
     target: browserslistToEsbuild(),


### PR DESCRIPTION
When building I noticed two things:

 - we were outputting the CSS file as `dist/style.css.css`
 - this log message:
  ```
   Warning: G] The conditions "types" and "style" here will never be used as they come after both "import" and "require" [package.json]

    package.json:13:6:
      13 │       "types": "./dist/index.d.ts",
         ╵       ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:12:6:
      12 │       "import": "./dist/index.js",
         ╵       ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:11:6:
      11 │       "require": "./dist/index.cjs",
         ╵       ~~~~~~~~~
  ```


I think this is why importing `@vector-im/compound-web` in a CSS file did not work out of the box, so that should fix it.
