### PR TITLE
Update react-context-menu to 2.2.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.27.0",
-    "@radix-ui/react-context-menu": "^2.2.1",
+    "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-form": "^0.1.0",
     "@radix-ui/react-progress": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,7 +870,7 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
   integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
 
-"@radix-ui/react-context-menu@^2.2.1":
+"@radix-ui/react-context-menu@^2.2.16":
   version "2.2.16"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz#e7bf94a457b68af08f24ad696949144530faab50"
   integrity sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==


### PR DESCRIPTION
So that https://github.com/radix-ui/primitives/pull/3614 gets included in downstream builds, like EW(And fix https://github.com/element-hq/element-web/issues/30610).

I mistakenly understood this to already have been included in the previous compound release, alas it was resolved in the lockfile but not updated in the package.json so EW was picking up a previous patch version.