### PR TITLE
If props are not omitted overwriting them should work for UnstyledButton

### DIFF
--- a/src/components/Button/UnstyledButton.tsx
+++ b/src/components/Button/UnstyledButton.tsx
@@ -83,16 +83,16 @@ export const UnstyledButton = forwardRef(function UnstyledButton<
 
   return (
     <Component
+      ref={ref as Ref<C>}
+      className={className}
       // The elements roles should be set to button default, or link in the case of anchors.
       // This should be overridable by props, say for example if you want to use a button as an option within a listbox.
       // Hence it taking precedence over restProps.
       role={as === "a" ? "link" : "button"}
-      {...restProps}
-      ref={ref as Ref<C>}
-      className={className}
       tabIndex={0}
-      {...eventHandlers}
       aria-disabled={disabled}
+      {...restProps}
+      {...eventHandlers}
     >
       {children}
     </Component>


### PR DESCRIPTION
If props are not Omitted overwriting them should work for UnstyledButton. For the new chat filters on the new room list in element web we are using listbox/option as roles, so we need to be able to override the role of the button.