### PR TITLE
Use classNames to merge classes in InlineSpinner

### DIFF
--- a/src/components/InlineSpinner/InlineSpinner.tsx
+++ b/src/components/InlineSpinner/InlineSpinner.tsx
@@ -6,6 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React, { type SVGAttributes, forwardRef } from "react";
+import classNames from "classnames";
 import styles from "./InlineSpinner.module.css";
 import SpinnerIcon from "@vector-im/compound-design-tokens/assets/web/icons/spinner";
 
@@ -14,11 +15,11 @@ type InlineSpinnerProps = {
 } & SVGAttributes<SVGElement>;
 
 export const InlineSpinner = forwardRef<SVGSVGElement, InlineSpinnerProps>(
-  function InlineSpinner({ size = 20, ...props }, ref) {
+  function InlineSpinner({ size = 20, className, ...props }, ref) {
     return (
       <SpinnerIcon
         ref={ref}
-        className={styles.icon}
+        className={classNames(styles.icon, className)}
         style={{ width: size, height: size }}
         {...props}
       />


### PR DESCRIPTION
As without it, specifying a className breaks compound styling of the component