### PR TITLE
Switch to NPM trusted publishing

### DIFF
--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -52,6 +52,7 @@ jobs:
         id: npm-publish
         run: |
           npm publish --access public --provenance
+          echo "version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
 
       - name: 🧬 Create release
         uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1


### PR DESCRIPTION
For https://gh.io/all-npm-classic-tokens-revoked etc, we need to move to using trusted publishing. I've just copied the workflows we have for other repositories.