### PR TITLE
Fix color of primary icon button

### DIFF
--- a/src/components/Button/IconButton/IconButton.module.css
+++ b/src/components/Button/IconButton/IconButton.module.css
@@ -27,7 +27,7 @@ Please see LICENSE files in the repository root for full details.
 
 .icon-button[data-kind="primary"] {
   * {
-    color: var(--cpd-color-icon-tertiary);
+    color: var(--cpd-color-icon-secondary);
   }
 }
 


### PR DESCRIPTION
According to [Figma](https://www.figma.com/design/rTaQE2nIUSLav4Tg3nozq7/Compound-Web-Components?node-id=1090-9924&t=KMr1YWquzUjPZic9-4), the color of primary the icon button should be `Light/color/icon/secondary`