### PR TITLE
Fix build outputs, post-typescript-6.0

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }],
   "compilerOptions": {
+    "rootDir": "./src",
     "lib": ["es2022", "dom", "dom.iterable"],
     // We import React as an unused local in order to support React 17
     "noUnusedLocals": false,


### PR DESCRIPTION
The structure of compound-web 9.0.0 is incorrect (for example, `dist/index.d.ts` has moved to `dist/src/index.d.ts`).

This is a result of the upgrade to Typescript v6 (in https://github.com/element-hq/compound-web/pull/461). As the [Typescript release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#up-front-adjustments) mention, this is because the default behaviour of `rootDir` changed in Typescript v6.