### PR TITLE
Export PageHeader from compiled library

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export { Breadcrumb } from "./components/Breadcrumb";
 export { VisualList, VisualListItem } from "./components/VisualList";
 export { ChatFilter } from "./components/ChatFilter";
 export { UnreadCounter, Pill, Unread } from "./components/ActivityMarker";
+export { PageHeader } from "./components/PageHeader/PageHeader";
 
 export {
   TextControl,


### PR DESCRIPTION
PR #467 added the `PageHeader` component, but didn't export it from index.html