### PR TITLE
Use stable identifiers for generated CSS class names

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -78,6 +78,15 @@ export default defineConfig({
     }),
   ],
 
+  css: {
+    modules: {
+      // Attempt to give generated CSS class names relatively stable identifiers.
+      // By default they include a hash of the css module file, and the line number within the file.
+      // Instead, let's just use the filename of the component for disambiguation.
+      generateScopedName: "_cpd-[path]_[local]",
+    },
+  },
+
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
Currently, there is typically a lot of work to do after upgrading between compound-web releases, in updating test snapshots. This is because CSS classes are named based on a hash of the class module's *contents*.

Currently, classes have names like `._text-content_zx76t_44`, where `text-button` is the original css name, `zx76t` is a hash of the css module file, and `44` is the line number within the file.

We switch to names like `_cpd-src-components-Alert-_text-content`, where `src-components-Alert-` is the path to the CSS module (with `/` replaced by `-`).