### PR TITLE
Import useId directly from React

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,13 +19,19 @@ module.exports = {
   },
   rules: {
     "prettier/prettier": "error",
-    "no-restricted-imports": ["error", {
-      "paths": [{
-        "name": "@floating-ui/react",
-        "importNames": ["useId"],
-        "message": "Please use useId from React directly: Compound only supports React 18+ and floating-ui's wrapper breaks mocks that make the IDs consistent in tests.",
-      }],
-    }],
+    "no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            name: "@floating-ui/react",
+            importNames: ["useId"],
+            message:
+              "Please use useId from React directly: Compound only supports React 18+ and floating-ui's wrapper breaks mocks that make the IDs consistent in tests.",
+          },
+        ],
+      },
+    ],
   },
   plugins: ["prettier", "react", "@typescript-eslint", "matrix-org"],
   settings: {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,6 +19,13 @@ module.exports = {
   },
   rules: {
     "prettier/prettier": "error",
+    "no-restricted-imports": ["error", {
+      "paths": [{
+        "name": "@floating-ui/react",
+        "importNames": ["useId"],
+        "message": "Please use useId from React directly: compound only support React 18+ and floating-ui's wrapper breaks mocks that make the IDs consistent in tests.",
+      }],
+    }],
   },
   plugins: ["prettier", "react", "@typescript-eslint", "matrix-org"],
   settings: {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,7 +23,7 @@ module.exports = {
       "paths": [{
         "name": "@floating-ui/react",
         "importNames": ["useId"],
-        "message": "Please use useId from React directly: compound only support React 18+ and floating-ui's wrapper breaks mocks that make the IDs consistent in tests.",
+        "message": "Please use useId from React directly: Compound only supports React 18+ and floating-ui's wrapper breaks mocks that make the IDs consistent in tests.",
       }],
     }],
   },

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -22,12 +22,12 @@ import React, {
   useState,
   type KeyboardEvent,
   useMemo,
+  useId,
 } from "react";
 
 import classNames from "classnames";
 
 import styles from "./Dropdown.module.css";
-import { useId } from "@floating-ui/react";
 
 type DropdownProps = {
   /**

--- a/src/components/ReleaseAnnouncement/useReleaseAnnouncement.tsx
+++ b/src/components/ReleaseAnnouncement/useReleaseAnnouncement.tsx
@@ -13,11 +13,10 @@ import {
   type Placement,
   shift,
   useFloating,
-  useId,
   useInteractions,
   useRole,
 } from "@floating-ui/react";
-import { type MouseEventHandler, useMemo, useRef } from "react";
+import { type MouseEventHandler, useMemo, useRef, useId } from "react";
 
 interface UseReleaseAnnouncementProps {
   /**

--- a/src/components/Tooltip/useTooltip.ts
+++ b/src/components/Tooltip/useTooltip.ts
@@ -18,7 +18,6 @@ import {
   useFloating,
   useFocus,
   useHover,
-  useId,
   useInteractions,
   useRole,
 } from "@floating-ui/react";
@@ -29,6 +28,7 @@ import {
   type JSX,
   type AriaAttributes,
   useEffect,
+  useId,
 } from "react";
 import { hoverDelay } from "./TooltipProvider";
 


### PR DESCRIPTION
As per the eslint message, floating-ui's useId wrapper messes up mocking of useId that's useful for making it return consistent IDs in tests.