### PR TITLE
Don't erase classname when passing props to menu item

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -145,7 +145,7 @@ export const MenuItem = <C extends MenuItemElement = "button">({
 
       {label !== null && (
         <Text
-          className={styles.label}
+          className={classnames(styles.label, labelProps?.className)}
           size="md"
           weight="medium"
           as="span"


### PR DESCRIPTION
Don't erase classname when passing props to menu item