### PR TITLE
feat(Tooltip): add boundary prop to hide tooltip when it escapes an element

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -127,6 +127,9 @@ function TooltipContent({
   // Label tooltips are kept in the DOM even when not visually open
   if (!open && purpose !== "label") return null;
 
+  // Hide the tooltip if it has escaped its boundary (when `boundary` prop is set)
+  const escaped = floatingContext.middlewareData?.hide?.escaped ?? false;
+
   return (
     <FloatingPortal>
       <div
@@ -135,7 +138,7 @@ function TooltipContent({
         {...rest.tooltipProps}
         {...rest.getFloatingProps()}
         className={classNames(styles.tooltip, {
-          [styles.invisible]: purpose === "label" && !open,
+          [styles.invisible]: (purpose === "label" && !open) || escaped,
         })}
       >
         <FloatingArrow

--- a/src/components/Tooltip/useTooltip.ts
+++ b/src/components/Tooltip/useTooltip.ts
@@ -87,7 +87,7 @@ export interface CommonUseTooltipProps {
    * near containers they should not overlap (e.g. the message composer).
    * @default undefined
    */
-  boundary?: Element | null | Element[];
+  boundary?: Element | Element[];
 
   /**
    * Additional aria-* attributes to pass through to the floating tooltip for
@@ -156,19 +156,14 @@ export function useTooltip({
         crossAxis: placement.includes("-"),
         fallbackAxisSideDirection: "start",
         padding: 5,
-        // Only pass boundary if set — FloatingUI's Boundary type excludes null
-        ...(boundary ? { boundary } : {}),
+        boundary,
       }),
       shift({ padding: 5 }),
-      ...(boundary
-        ? [
-            hide({
-              strategy: "escaped",
-              boundary,
-              padding: 6,
-            }),
-          ]
-        : []),
+      hide({
+        strategy: "escaped",
+        boundary,
+        padding: 6,
+      }),
       // add the little arrow along with the floating content
       arrow({
         element: arrowRef,

--- a/src/components/Tooltip/useTooltip.ts
+++ b/src/components/Tooltip/useTooltip.ts
@@ -9,6 +9,7 @@ import {
   arrow,
   autoUpdate,
   flip,
+  hide,
   offset,
   type OpenChangeReason,
   type Placement,
@@ -78,6 +79,17 @@ export interface CommonUseTooltipProps {
   isTriggerInteractive: boolean;
 
   /**
+   * An optional boundary element to constrain the tooltip within.
+   * When provided, the tooltip will be hidden if it escapes this boundary.
+   * Also passed to the `flip` middleware so it can choose a placement that
+   * keeps the tooltip inside the boundary.
+   * Accepts a single Element or an array of Elements. Useful for tooltips
+   * near containers they should not overlap (e.g. the message composer).
+   * @default undefined
+   */
+  boundary?: Element | null | Element[];
+
+  /**
    * Additional aria-* attributes to pass through to the floating tooltip for
    * edge cases which require more user awareness like errors & alerts.
    */
@@ -111,6 +123,7 @@ export function useTooltip({
   caption,
   "aria-atomic": ariaAtomic,
   "aria-live": ariaLive,
+  boundary,
   ...props
 }: UseTooltipProps) {
   const labelId = useId();
@@ -143,8 +156,19 @@ export function useTooltip({
         crossAxis: placement.includes("-"),
         fallbackAxisSideDirection: "start",
         padding: 5,
+        // Only pass boundary if set — FloatingUI's Boundary type excludes null
+        ...(boundary ? { boundary } : {}),
       }),
       shift({ padding: 5 }),
+      ...(boundary
+        ? [
+            hide({
+              strategy: "escaped",
+              boundary,
+              padding: 6,
+            }),
+          ]
+        : []),
       // add the little arrow along with the floating content
       arrow({
         element: arrowRef,


### PR DESCRIPTION
## Summary

Adds an optional `boundary` prop to `useTooltip` (and therefore `Tooltip`) that activates FloatingUI's `hide` middleware with `strategy: "escaped"`. When the tooltip would overflow the provided boundary, the floating element receives the existing `invisible` class (`clip-path: inset(50%)` + `pointer-events: none`), allowing it to remain in the accessibility tree while being visually hidden.

The boundary is also forwarded to the `flip` middleware so the initial placement is more likely to remain within the same boundary.

The prop is fully backward compatible. When `boundary` is omitted, tooltip behavior remains unchanged.

## Motivation

Element Web's "Expand map" tooltip on location messages can overlap the message composer at the bottom of the timeline. Constraining the tooltip to the message panel boundary allows it to hide cleanly when it would escape that area, without requiring consumers to implement their own FloatingUI middleware configuration.

## Implementation

`useTooltip.ts` adds `boundary?: Element | null | Element[]` to `CommonUseTooltipProps`, forwards it to the existing `flip` middleware, and conditionally appends `hide({ strategy: "escaped", boundary, padding: 6 })` to the middleware list. `Tooltip.tsx` reads `middlewareData?.hide?.escaped` and applies the existing `invisible` class when true. No CSS change is needed.

## Follow-up

A corresponding Element Web PR will consume this prop on `MLocationBody` to keep the "Expand map" tooltip from overlapping the message composer. That PR will land in element-hq/element-web once this change is merged and a new `@vector-im/compound-web` version is published.
