### PR TITLE
Split out the menu part of dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.module.css
+++ b/src/components/Dropdown/Dropdown.module.css
@@ -1,5 +1,6 @@
 /*
 Copyright 2024 New Vector Ltd.
+Copyright 2026 Element Creations Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -6,14 +6,11 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import ChevronDown from "@vector-im/compound-design-tokens/assets/web/icons/chevron-down";
-import Check from "@vector-im/compound-design-tokens/assets/web/icons/check";
 import Error from "@vector-im/compound-design-tokens/assets/web/icons/error-solid";
 
 import React, {
   type Dispatch,
   forwardRef,
-  type HTMLProps,
-  memo,
   type RefObject,
   type SetStateAction,
   useCallback,
@@ -28,6 +25,7 @@ import React, {
 import classNames from "classnames";
 
 import styles from "./Dropdown.module.css";
+import { DropdownMenu } from "./DropdownMenu";
 
 type DropdownProps = {
   /**
@@ -125,12 +123,6 @@ export const Dropdown = forwardRef<HTMLButtonElement, DropdownProps>(
     const buttonClasses = classNames({
       [styles.placeholder]: hasPlaceholder,
     });
-    const borderClasses = classNames(styles.border, {
-      [styles.open]: open,
-    });
-    const contentClasses = classNames(styles.content, {
-      [styles.open]: open,
-    });
 
     /**
      * Ids for accessibility.
@@ -169,30 +161,18 @@ export const Dropdown = forwardRef<HTMLButtonElement, DropdownProps>(
           {text}
           <ChevronDown width="24" height="24" />
         </button>
-        <div className={borderClasses} />
-        <div className={contentClasses}>
-          <ul
-            ref={listRef}
-            id={contentId}
-            role="listbox"
-            className={styles.content}
-          >
-            {values.map(([v, text]) => (
-              <DropdownItem
-                key={v}
-                isDisplayed={open}
-                isSelected={value === v}
-                onClick={() => {
-                  setOpen(false);
-                  setValue(v);
-                }}
-                onKeyDown={(e) => onOptionKeyDown(e, v)}
-              >
-                {text}
-              </DropdownItem>
-            ))}
-          </ul>
-        </div>
+        <DropdownMenu
+          open={open}
+          values={values}
+          selectedValue={value}
+          id={contentId}
+          listRef={listRef}
+          onOptionKeyDown={onOptionKeyDown}
+          onSelect={(v) => {
+            setOpen(false);
+            setValue(v);
+          }}
+        />
         {!error && helpLabel && (
           <span className={styles.help}>{helpLabel}</span>
         )}
@@ -206,52 +186,6 @@ export const Dropdown = forwardRef<HTMLButtonElement, DropdownProps>(
     );
   },
 );
-
-type DropdownItemProps = HTMLProps<HTMLLIElement> & {
-  /**
-   * Whether the dropdown item is selected.
-   */
-  isSelected: boolean;
-  /**
-   * Whether the dropdown item is displayed.
-   */
-  isDisplayed: boolean;
-  /**
-   * The text to display in the dropdown item.
-   */
-  children: string;
-};
-
-/**
- * A dropdown item component.
- */
-const DropdownItem = memo(function DropdownItem({
-  children,
-  isSelected,
-  isDisplayed,
-  ...props
-}: DropdownItemProps) {
-  const ref = useRef<HTMLLIElement>(null);
-
-  // Focus the item if the dropdown is open and the item is already selected
-  useEffect(() => {
-    if (isSelected && isDisplayed) {
-      ref.current?.focus();
-    }
-  }, [isSelected, isDisplayed]);
-
-  return (
-    <li
-      tabIndex={0}
-      role="option"
-      ref={ref}
-      aria-selected={isSelected}
-      {...props}
-    >
-      {children} {isSelected && <Check width="20" height="20" />}
-    </li>
-  );
-});
 
 /**
  * A hook to manage the open state of the dropdown.

--- a/src/components/Dropdown/DropdownMenu.module.css
+++ b/src/components/Dropdown/DropdownMenu.module.css
@@ -1,0 +1,68 @@
+/*
+Copyright 2024 New Vector Ltd.
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+.border {
+  display: none;
+  border-inline-start: 1px solid var(--cpd-color-border-interactive-secondary);
+  border-inline-end: 1px solid var(--cpd-color-border-interactive-secondary);
+  block-size: var(--cpd-space-1x);
+  margin-block-start: calc(var(--cpd-space-1x) * -1);
+  box-sizing: border-box;
+}
+
+.content {
+  display: none;
+  position: relative;
+
+  ul {
+    /**
+     * To make the component going over the other elements
+     */
+    position: absolute;
+    display: block;
+    inline-size: 100%;
+    background: var(--cpd-color-bg-canvas-default);
+    border: 1px solid var(--cpd-color-border-interactive-secondary);
+    border-block-start: 0;
+    border-end-start-radius: var(--cpd-space-4x);
+    border-end-end-radius: var(--cpd-space-4x);
+    box-sizing: border-box;
+    box-shadow: 0 4px 24px 0 rgb(27 29 34 / 10%);
+    margin: 0;
+    padding: 0;
+    padding-block-end: var(--cpd-space-4x);
+    cursor: pointer;
+
+    li {
+      list-style-type: "";
+      font: var(--cpd-font-body-md-medium);
+      padding: var(--cpd-space-3x) var(--cpd-space-4x);
+      border-block-end: 1px solid var(--cpd-color-gray-300);
+      color: var(--cpd-color-text-secondary);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: var(--cpd-space-4x);
+
+      @media (hover) {
+        &:hover {
+          background: var(--cpd-color-gray-200);
+        }
+      }
+
+      &[aria-selected="true"] {
+        color: var(--cpd-color-text-primary);
+        background: var(--cpd-color-gray-300);
+      }
+    }
+  }
+}
+
+.open {
+  display: block;
+}

--- a/src/components/Dropdown/DropdownMenu.tsx
+++ b/src/components/Dropdown/DropdownMenu.tsx
@@ -1,0 +1,131 @@
+/*
+Copyright 2024 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import Check from "@vector-im/compound-design-tokens/assets/web/icons/check";
+
+import React, {
+  type HTMLProps,
+  memo,
+  type RefObject,
+  useEffect,
+  useRef,
+  type KeyboardEvent,
+} from "react";
+
+import classNames from "classnames";
+
+import styles from "./DropdownMenu.module.css";
+
+type DropdownMenuProps = {
+  /**
+   * Whether the menu is open.
+   */
+  open: boolean;
+  /**
+   * The values to display in the menu.
+   * [value, text]
+   */
+  values: [string, string][];
+  /**
+   * The currently selected value.
+   */
+  selectedValue: string | undefined;
+  /**
+   * The id for the listbox element (used for aria-controls on the trigger).
+   */
+  id: string;
+  /**
+   * Ref to the underlying ul element for keyboard navigation.
+   */
+  listRef: RefObject<HTMLUListElement | null>;
+  /**
+   * Keyboard event handler for individual options.
+   */
+  onOptionKeyDown: (e: KeyboardEvent<HTMLLIElement>, value: string) => void;
+  /**
+   * Called when the user selects an option.
+   */
+  onSelect: (value: string) => void;
+};
+
+/**
+ * The popup listbox portion of a Dropdown: scrollable
+ * list container, and option items.
+ */
+export function DropdownMenu({
+  open,
+  values,
+  selectedValue,
+  id,
+  listRef,
+  onOptionKeyDown,
+  onSelect,
+}: DropdownMenuProps) {
+  return (
+    <>
+      <div className={classNames(styles.border, { [styles.open]: open })} />
+      <div className={classNames(styles.content, { [styles.open]: open })}>
+        <ul ref={listRef} id={id} role="listbox">
+          {values.map(([v, text]) => (
+            <DropdownItem
+              key={v}
+              isDisplayed={open}
+              isSelected={selectedValue === v}
+              onClick={() => onSelect(v)}
+              onKeyDown={(e) => onOptionKeyDown(e, v)}
+            >
+              {text}
+            </DropdownItem>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}
+
+type DropdownItemProps = HTMLProps<HTMLLIElement> & {
+  /**
+   * Whether the dropdown item is selected.
+   */
+  isSelected: boolean;
+  /**
+   * Whether the dropdown is open (used to auto-focus selected item).
+   */
+  isDisplayed: boolean;
+  /**
+   * The text to display in the dropdown item.
+   */
+  children: string;
+};
+
+const DropdownItem = memo(function DropdownItem({
+  children,
+  isSelected,
+  isDisplayed,
+  ...props
+}: DropdownItemProps) {
+  const ref = useRef<HTMLLIElement>(null);
+
+  // Focus the item if the dropdown is open and the item is already selected
+  useEffect(() => {
+    if (isSelected && isDisplayed) {
+      ref.current?.focus();
+    }
+  }, [isSelected, isDisplayed]);
+
+  return (
+    <li
+      tabIndex={0}
+      role="option"
+      ref={ref}
+      aria-selected={isSelected}
+      {...props}
+    >
+      {children} {isSelected && <Check width="20" height="20" />}
+    </li>
+  );
+});

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -33,13 +33,12 @@ exports[`Dropdown > can be opened 1`] = `
       </svg>
     </button>
     <div
-      class="_border_1f39d3 _open_1f39d3"
+      class="_border_053716 _open_053716"
     />
     <div
-      class="_content_1f39d3 _open_1f39d3"
+      class="_content_053716 _open_053716"
     >
       <ul
-        class="_content_1f39d3"
         id="_r_9_"
         role="listbox"
       >
@@ -106,13 +105,12 @@ exports[`Dropdown > can select a value 1`] = `
       </svg>
     </button>
     <div
-      class="_border_1f39d3 _open_1f39d3"
+      class="_border_053716 _open_053716"
     />
     <div
-      class="_content_1f39d3 _open_1f39d3"
+      class="_content_053716 _open_053716"
     >
       <ul
-        class="_content_1f39d3"
         id="_r_b_"
         role="listbox"
       >
@@ -190,13 +188,12 @@ exports[`Dropdown > renders a Default dropdown 1`] = `
       </svg>
     </button>
     <div
-      class="_border_1f39d3"
+      class="_border_053716"
     />
     <div
-      class="_content_1f39d3"
+      class="_content_053716"
     >
       <ul
-        class="_content_1f39d3"
         id="_r_1_"
         role="listbox"
       >
@@ -263,13 +260,12 @@ exports[`Dropdown > renders a dropdown with a default value  1`] = `
       </svg>
     </button>
     <div
-      class="_border_1f39d3"
+      class="_border_053716"
     />
     <div
-      class="_content_1f39d3"
+      class="_content_053716"
     >
       <ul
-        class="_content_1f39d3"
         id="_r_7_"
         role="listbox"
       >
@@ -347,13 +343,12 @@ exports[`Dropdown > renders a dropdown with a help label 1`] = `
       </svg>
     </button>
     <div
-      class="_border_1f39d3"
+      class="_border_053716"
     />
     <div
-      class="_content_1f39d3"
+      class="_content_053716"
     >
       <ul
-        class="_content_1f39d3"
         id="_r_3_"
         role="listbox"
       >
@@ -425,13 +420,12 @@ exports[`Dropdown > renders a dropdown with an error  1`] = `
       </svg>
     </button>
     <div
-      class="_border_1f39d3"
+      class="_border_053716"
     />
     <div
-      class="_content_1f39d3"
+      class="_content_053716"
     >
       <ul
-        class="_content_1f39d3"
         id="_r_5_"
         role="listbox"
       >

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -62,8 +62,15 @@ const meta = {
   title: "Menu",
   component: Template,
   tags: ["autodocs", "axe-exclude"],
-  argTypes: {},
-  args: {},
+  argTypes: {
+    side: {
+      control: "select",
+      options: ["top", "right", "bottom", "left"],
+    },
+  },
+  args: {
+    side: "bottom",
+  },
 } satisfies Meta<typeof Template>;
 export default meta;
 


### PR DESCRIPTION
To allow it to be used separately from Dropdown itself, as we now have designs that require this.

It could also probably be unified a bit with other menu components, this splits it out to make this possible.