### PR TITLE
Fix Tooltips sometimes not rendering

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -52,9 +52,9 @@ const meta = {
   args: {
     // needed, to prevent the tooltip to be in controlled mode
     onOpenChange: undefined,
-    open: undefined,
+    open: true,
     description: "",
-    label: "",
+    label: "@bob:example.org",
     children: (
       <IconButton>
         <UserIcon />
@@ -92,7 +92,7 @@ const Layout: FC<LayoutProps> = ({ children }) => (
   </div>
 );
 
-const TemplatePlacement: StoryFn<typeof meta> = () => (
+const TemplatePlacement: StoryFn<typeof meta.args> = (args) => (
   <Layout>
     {(
       [
@@ -106,12 +106,7 @@ const TemplatePlacement: StoryFn<typeof meta> = () => (
         "left-start",
       ] as Array<PlacementType>
     ).map((placement) => (
-      <TooltipComponent
-        key={placement}
-        open={true}
-        placement={placement}
-        label="@bob:example.org"
-      >
+      <TooltipComponent {...args} key={placement} placement={placement}>
         <IconButton>
           <UserIcon />
         </IconButton>

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -34,7 +34,11 @@ const meta = {
       options: ["top", "right", "left", "bottom"],
     },
     open: {
-      control: "boolean",
+      control: "inline-radio",
+      options: ["auto", false, true],
+      mapping: {
+        auto: undefined,
+      },
     },
     isTriggerInteractive: {
       control: "boolean",
@@ -52,9 +56,9 @@ const meta = {
   args: {
     // needed, to prevent the tooltip to be in controlled mode
     onOpenChange: undefined,
-    open: true,
+    open: undefined as boolean | undefined,
     description: "",
-    label: "@bob:example.org",
+    label: "",
     children: (
       <IconButton>
         <UserIcon />
@@ -116,7 +120,10 @@ const TemplatePlacement: StoryFn<typeof meta.args> = (args) => (
 );
 
 export const Placement = TemplatePlacement.bind({});
-Placement.args = {};
+Placement.args = {
+  open: true,
+  label: "@bob:example.org",
+};
 
 export const Default: Story = {
   args: {

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -73,7 +73,7 @@ describe("Tooltip", () => {
   it("renders default tooltip", async () => {
     render(
       <TooltipProvider>
-        <Tooltip label="@bob:example.org">
+        <Tooltip label="@bob:example.org" boundary="clippingAncestors">
           <IconButton>
             <UserIcon />
           </IconButton>

--- a/src/components/Tooltip/useTooltip.ts
+++ b/src/components/Tooltip/useTooltip.ts
@@ -8,6 +8,7 @@
 import {
   arrow,
   autoUpdate,
+  type Boundary,
   flip,
   hide,
   offset,
@@ -85,9 +86,11 @@ export interface CommonUseTooltipProps {
    * keeps the tooltip inside the boundary.
    * Accepts a single Element or an array of Elements. Useful for tooltips
    * near containers they should not overlap (e.g. the message composer).
+   * Additionally, accepts `clippingAncestors`,
+   * which are the overflow ancestors which will cause the element to be clipped.
    * @default undefined
    */
-  boundary?: Element | Element[];
+  boundary?: Boundary;
 
   /**
    * Additional aria-* attributes to pass through to the floating tooltip for
@@ -159,11 +162,14 @@ export function useTooltip({
         boundary,
       }),
       shift({ padding: 5 }),
-      hide({
-        strategy: "escaped",
-        boundary,
-        padding: 6,
-      }),
+      // only load the hide middleware if `boundary` is specified otherwise it will default to `clippingAncestors`
+      boundary
+        ? hide({
+            strategy: "escaped",
+            boundary,
+            padding: 6,
+          })
+        : null,
       // add the little arrow along with the floating content
       arrow({
         element: arrowRef,


### PR DESCRIPTION
due to hide middleware defaulting to clippingAncestors

Regressed by https://github.com/element-hq/compound-web/pull/506
For https://github.com/element-hq/element-web/issues/34067