### PR TITLE
Fix running end-to-end tests via Docker

### DIFF
--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -12,4 +12,4 @@ RUN usermod -ou $UID -g $GID pwuser
 USER pwuser
 
 WORKDIR /work/compound-web
-ENTRYPOINT ["node", "node_modules/playwright/cli.js", "test"]
+ENTRYPOINT ["node", "node_modules/@playwright/test/cli.js", "test"]


### PR DESCRIPTION
Makes `pnpm e2e:docker` work again. The Playwright CLI is in a different place after the migration to pnpm.