### PR TITLE
Fix active Switch icon being invisible in forced colors mode

### DIFF
--- a/src/components/Switch/Switch.module.css
+++ b/src/components/Switch/Switch.module.css
@@ -108,7 +108,9 @@ Please see LICENSE in the repository root for full details.
   }
 
   input:checked + svg {
-    color: var(--cpd-color-icon-on-solid-primary);
+    @media not (forced-colors) {
+      color: var(--cpd-color-icon-on-solid-primary);
+    }
   }
 
   input:checked:active {


### PR DESCRIPTION
Sorry, hit one more issue with the Switch component when I finally managed to activate forced colors on Chromium…

|Before|After|
|-|-|
|<img width="121" height="65" alt="Screenshot From 2026-07-09 18-30-28" src="https://github.com/user-attachments/assets/403d75bc-8ab0-439d-bddd-4cf238cdccbb" />|<img width="121" height="65" alt="Screenshot From 2026-07-09 18-30-18" src="https://github.com/user-attachments/assets/9288a953-eb6f-4ac6-8afb-2f3664a3914d" />|
