### PR TITLE
Change Dropdown to have a renderItem callback

### DIFF
--- a/src/components/Dropdown/Dropdown.module.css
+++ b/src/components/Dropdown/Dropdown.module.css
@@ -91,7 +91,10 @@ Please see LICENSE files in the repository root for full details.
         padding: var(--cpd-space-3x) var(--cpd-space-4x);
         border-block-end: 1px solid var(--cpd-color-gray-300);
         color: var(--cpd-color-text-secondary);
+        display: flex;
+        justify-content: space-between;
         align-items: center;
+        gap: var(--cpd-space-4x);
 
         @media (hover) {
           &:hover {

--- a/src/components/Dropdown/Dropdown.module.css
+++ b/src/components/Dropdown/Dropdown.module.css
@@ -91,10 +91,7 @@ Please see LICENSE files in the repository root for full details.
         padding: var(--cpd-space-3x) var(--cpd-space-4x);
         border-block-end: 1px solid var(--cpd-color-gray-300);
         color: var(--cpd-color-text-secondary);
-        display: flex;
-        justify-content: space-between;
         align-items: center;
-        gap: var(--cpd-space-4x);
 
         @media (hover) {
           &:hover {

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -25,24 +25,18 @@ const meta = {
     error: {
       type: "string",
     },
-    placeholder: {
-      type: "string",
-    },
     values: {
       type: "string",
     },
   },
   args: {
     label: "Label",
-    placeholder: "Select an option",
     onValueChange: fn(),
-    values: [
-      ["Option1", "Option 1"],
-      ["Option2", "Option 2"],
-      ["Option3", "Option 3"],
-    ],
+    values: ["Option1", "Option2", "Option3"],
+    renderItem: (value) =>
+      value ? value?.replace("Option", "Option ") : "Select an option",
   },
-} satisfies Meta<ComponentProps<typeof Dropdown>>;
+} satisfies Meta<ComponentProps<typeof Dropdown<string>>>;
 export default meta;
 
 type Story = StoryObj<typeof meta>;

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -18,20 +18,14 @@ const { Default, WithHelpLabel, WithError, WithDefaultValue } =
 
 const ControlledDropdown: FC = () => {
   const [value, setValue] = useState("1");
-  const values = useMemo<[string, string][]>(
-    () => [
-      ["1", "Option 1"],
-      ["2", "Option 2"],
-    ],
-    [],
-  );
+  const values = useMemo<string[]>(() => ["1", "2"], []);
   return (
     <Dropdown
       value={value}
       onValueChange={setValue}
       values={values}
-      placeholder=""
       label="Label"
+      renderItem={(value) => "Option " + value}
     />
   );
 };
@@ -105,17 +99,14 @@ describe("Dropdown", () => {
     const user = userEvent.setup();
     render(
       <Dropdown
-        values={[
-          ["1", "Option 1"],
-          ["2", "Option 2"],
-        ]}
-        placeholder={null}
+        values={["1", "2"]}
         label={null}
         trigger={(props) => (
           <button {...props} aria-label="Custom trigger">
             Custom trigger
           </button>
         )}
+        renderItem={(value) => "Option " + value}
       />,
     );
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -198,7 +198,7 @@ export function Dropdown<K extends string | number = string>({
           ref={combinedRef}
           {...props}
         >
-          {currentContent}
+          <div>{currentContent}</div>
           <ChevronDown className={styles.chevron} width="24" height="24" />
         </button>
       )}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -44,7 +44,7 @@ export type DropdownTriggerProps = {
   onKeyDown?: (e: KeyboardEvent<Element>) => void;
 };
 
-export type DropdownProps<K extends string | number = string> = {
+type DropdownProps<K extends string | number = string> = {
   /**
    * The CSS class name.
    */

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -44,7 +44,7 @@ export type DropdownTriggerProps = {
   onKeyDown?: (e: KeyboardEvent<Element>) => void;
 };
 
-type DropdownProps<K extends string | number = string> = {
+type DropdownProps<K = string> = {
   /**
    * The CSS class name.
    */

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,9 +1,11 @@
 /*
-Copyright 2024 New Vector Ltd.
-
-SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
-Please see LICENSE files in the repository root for full details.
-*/
+ * Copyright 2024 New Vector Ltd.
+ * Copyright 2026 Element Creations Ltd.
+ *
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
 
 import ChevronDown from "@vector-im/compound-design-tokens/assets/web/icons/chevron-down";
 import Check from "@vector-im/compound-design-tokens/assets/web/icons/check";
@@ -11,9 +13,9 @@ import Error from "@vector-im/compound-design-tokens/assets/web/icons/error-soli
 
 import React, {
   type Dispatch,
-  forwardRef,
   type HTMLProps,
   memo,
+  type Ref,
   type RefObject,
   type SetStateAction,
   useCallback,
@@ -42,7 +44,7 @@ export type DropdownTriggerProps = {
   onKeyDown?: (e: KeyboardEvent<Element>) => void;
 };
 
-type DropdownProps = {
+export type DropdownProps<K extends string | number = string> = {
   /**
    * The CSS class name.
    */
@@ -50,22 +52,17 @@ type DropdownProps = {
   /**
    * The controlled value of the dropdown.
    */
-  value?: string;
+  value?: K;
   /**
    * The default value of the dropdown, used when uncontrolled.
    */
-  defaultValue?: string;
+  defaultValue?: K;
   /**
-   * The values of the dropdown.
-   * [value, text]
+   * The values of the items presented in the dropdown, in order.
+   * These are the values provided back to onValueChange and the values provided
+   * to renderItem, if provided.
    */
-  values: [string, string][];
-  /**
-   * The placeholder text.
-   * Required because it's unusual not to set this unless making a custom dropdown with a custom trigger,
-   * in which case you may explicitly pass null.
-   */
-  placeholder: string | null;
+  values: K[];
   /**
    * The label to display at the top of the dropdown
    * Required because it's unusual not to set this unless making a custom dropdown with a custom trigger,
@@ -80,7 +77,7 @@ type DropdownProps = {
    * Callback for when the value changes.
    * @param value
    */
-  onValueChange?: (value: string) => void;
+  onValueChange?: (value: K) => void;
   /**
    * The error message to display.
    */
@@ -91,153 +88,153 @@ type DropdownProps = {
    * Default: a button with the selected value or the placeholder text and a chevron down icon.
    */
   trigger?: (props: DropdownTriggerProps) => React.ReactNode;
+  /**
+   * A function render the node that represent a given item, given the value of that item.
+   * To render the placeholder, null is passed.
+   */
+  renderItem: (value: K | null) => React.ReactNode;
+  /**
+   * A ref to the default trigger button.
+   * Unused if a custom `trigger` is provided.
+   */
+  ref?: Ref<HTMLButtonElement>;
 };
 
 /**
- * The dropdown content.
+ * A dropdown that lets the user select one of a set of values.
+ * The type parameter `K` represents the set of values.
  */
-export const Dropdown = forwardRef<HTMLButtonElement, DropdownProps>(
-  function Dropdown(
-    {
-      className,
-      label,
-      placeholder,
-      helpLabel,
-      onValueChange,
-      error,
-      value: controlledValue,
-      defaultValue,
-      values,
-      trigger,
-      ...props
+export function Dropdown<K extends string | number = string>({
+  className,
+  label,
+  helpLabel,
+  onValueChange,
+  error,
+  value: controlledValue,
+  defaultValue,
+  values,
+  renderItem,
+  trigger,
+  ref,
+  ...props
+}: DropdownProps<K>) {
+  const [uncontrolledValue, setUncontrolledValue] = useState<K | undefined>(
+    defaultValue,
+  );
+  const value = controlledValue ?? uncontrolledValue ?? null;
+  const currentContent = useMemo(() => renderItem(value), [value, renderItem]);
+
+  const setValue = useCallback(
+    (value: K) => {
+      setUncontrolledValue(value);
+      onValueChange?.(value);
     },
-    ref,
-  ) {
-    const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
-    const value = controlledValue ?? uncontrolledValue;
-    const text = useMemo(
-      () =>
-        value === undefined
-          ? placeholder
-          : (values.find(([v]) => v === value)?.[1] ?? placeholder),
-      [value, values, placeholder],
-    );
+    [setUncontrolledValue, onValueChange],
+  );
 
-    const setValue = useCallback(
-      (value: string) => {
-        setUncontrolledValue(value);
-        onValueChange?.(value);
-      },
-      [setUncontrolledValue, onValueChange],
-    );
+  const [open, setOpen, dropdownRef] = useOpen();
+  const { listRef, onComboboxKeyDown, onOptionKeyDown } = useKeyboardShortcut(
+    open,
+    setOpen,
+    setValue,
+  );
 
-    const [open, setOpen, dropdownRef] = useOpen();
-    const { listRef, onComboboxKeyDown, onOptionKeyDown } = useKeyboardShortcut(
-      open,
-      setOpen,
-      setValue,
-    );
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  useEffect(() => {
+    // Focus the button when the value is set
+    // Test if the value is undefined to avoid focusing on the first render
+    if (value !== null) buttonRef.current?.focus();
+  }, [value]);
 
-    const buttonRef = useRef<HTMLButtonElement | null>(null);
-    useEffect(() => {
-      // Focus the button when the value is set
-      // Test if the value is undefined to avoid focusing on the first render
-      if (value !== undefined) buttonRef.current?.focus();
-    }, [value]);
+  const buttonClasses = classNames({
+    [styles["trigger-button"]]: true,
+    [styles.placeholder]: value === null,
+    [styles["open-trigger"]]: open,
+  });
+  const contentClasses = classNames(styles.content, {
+    [styles.open]: open,
+    [styles.seamless]: !trigger,
+  });
 
-    const hasPlaceholder = text === placeholder;
-    const buttonClasses = classNames({
-      [styles["trigger-button"]]: true,
-      [styles.placeholder]: hasPlaceholder,
-      [styles["open-trigger"]]: open,
-    });
-    const contentClasses = classNames(styles.content, {
-      [styles.open]: open,
-      [styles.seamless]: !trigger,
-    });
+  /**
+   * Ids for accessibility.
+   */
+  const labelId = useId();
+  const contentId = useId();
 
-    /**
-     * Ids for accessibility.
-     */
-    const labelId = useId();
-    const contentId = useId();
+  const combinedRef = (element: HTMLButtonElement | null) => {
+    buttonRef.current = element;
+    if (typeof ref === "function") {
+      ref(element);
+    } else if (ref) {
+      ref.current = element;
+    }
+  };
 
-    const combinedRef = (element: HTMLButtonElement | null) => {
-      buttonRef.current = element;
-      if (typeof ref === "function") {
-        ref(element);
-      } else if (ref) {
-        ref.current = element;
-      }
-    };
+  const triggerProps: DropdownTriggerProps = {
+    role: "combobox",
+    "aria-haspopup": "listbox",
+    "aria-controls": contentId,
+    "aria-expanded": open,
+    onClick: () => setOpen((_open) => !_open),
+    onKeyDown: onComboboxKeyDown,
+  };
 
-    const triggerProps: DropdownTriggerProps = {
-      role: "combobox",
-      "aria-haspopup": "listbox",
-      "aria-controls": contentId,
-      "aria-expanded": open,
-      onClick: () => setOpen((_open) => !_open),
-      onKeyDown: onComboboxKeyDown,
-    };
+  if (label) triggerProps["aria-labelledby"] = labelId;
 
-    if (label) triggerProps["aria-labelledby"] = labelId;
-
-    return (
-      <div
-        ref={dropdownRef}
-        className={classNames(className, styles.container)}
-        aria-invalid={Boolean(error)}
-      >
-        {label && <label id={labelId}>{label}</label>}
-        {trigger ? (
-          trigger(triggerProps)
-        ) : (
-          <button
-            className={buttonClasses}
-            {...triggerProps}
-            ref={combinedRef}
-            {...props}
-          >
-            {text}
-            <ChevronDown className={styles.chevron} width="24" height="24" />
-          </button>
-        )}
-        <div className={contentClasses}>
-          <ul
-            ref={listRef}
-            id={contentId}
-            role="listbox"
-            className={styles.content}
-          >
-            {values.map(([v, text]) => (
-              <DropdownItem
-                key={v}
-                isDisplayed={open}
-                isSelected={value === v}
-                onClick={() => {
-                  setOpen(false);
-                  setValue(v);
-                }}
-                onKeyDown={(e) => onOptionKeyDown(e, v)}
-              >
-                {text}
-              </DropdownItem>
-            ))}
-          </ul>
-        </div>
-        {!error && helpLabel && (
-          <span className={styles.help}>{helpLabel}</span>
-        )}
-        {error && (
-          <span className={styles.error}>
-            <Error width="20" height="20" />
-            {error}
-          </span>
-        )}
+  return (
+    <div
+      ref={dropdownRef}
+      className={classNames(className, styles.container)}
+      aria-invalid={Boolean(error)}
+    >
+      {label && <label id={labelId}>{label}</label>}
+      {trigger ? (
+        trigger(triggerProps)
+      ) : (
+        <button
+          className={buttonClasses}
+          {...triggerProps}
+          ref={combinedRef}
+          {...props}
+        >
+          {currentContent}
+          <ChevronDown className={styles.chevron} width="24" height="24" />
+        </button>
+      )}
+      <div className={contentClasses}>
+        <ul
+          ref={listRef}
+          id={contentId}
+          role="listbox"
+          className={styles.content}
+        >
+          {values.map((v) => (
+            <DropdownItem
+              key={v}
+              isDisplayed={open}
+              isSelected={value === v}
+              onClick={() => {
+                setOpen(false);
+                setValue(v);
+              }}
+              onKeyDown={(e) => onOptionKeyDown(e, v)}
+            >
+              {renderItem(v)}
+            </DropdownItem>
+          ))}
+        </ul>
       </div>
-    );
-  },
-);
+      {!error && helpLabel && <span className={styles.help}>{helpLabel}</span>}
+      {error && (
+        <span className={styles.error}>
+          <Error width="20" height="20" />
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
 
 type DropdownItemProps = HTMLProps<HTMLLIElement> & {
   /**
@@ -249,9 +246,9 @@ type DropdownItemProps = HTMLProps<HTMLLIElement> & {
    */
   isDisplayed: boolean;
   /**
-   * The text to display in the dropdown item.
+   * The content to display in the dropdown item.
    */
-  children: string;
+  children: React.ReactNode;
 };
 
 /**
@@ -317,10 +314,10 @@ function useOpen(): [
  * @param setOpen - the dropdown open state setter.
  * @param setValue - set the selected value and text
  */
-function useKeyboardShortcut(
+function useKeyboardShortcut<K extends string | number>(
   open: boolean,
   setOpen: Dispatch<SetStateAction<boolean>>,
-  setValue: (value: string) => void,
+  setValue: (value: K) => void,
 ) {
   const listRef = useRef<HTMLUListElement>(null);
   const onComboboxKeyDown = useCallback(
@@ -362,7 +359,7 @@ function useKeyboardShortcut(
   );
 
   const onOptionKeyDown = useCallback(
-    (evt: KeyboardEvent, value: string) => {
+    (evt: KeyboardEvent, value: K) => {
       const { key, altKey } = evt;
       evt.stopPropagation();
       evt.preventDefault();

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -19,7 +19,9 @@ exports[`Dropdown > can be opened 1`] = `
       class="_trigger-button_1f39d3 _placeholder_1f39d3 _open-trigger_1f39d3"
       role="combobox"
     >
-      Select an option
+      <div>
+        Select an option
+      </div>
       <svg
         class="_chevron_1f39d3"
         fill="currentColor"
@@ -90,7 +92,9 @@ exports[`Dropdown > can select a value 1`] = `
       class="_trigger-button_1f39d3 _open-trigger_1f39d3"
       role="combobox"
     >
-      Option 2
+      <div>
+        Option 2
+      </div>
       <svg
         class="_chevron_1f39d3"
         fill="currentColor"
@@ -172,7 +176,9 @@ exports[`Dropdown > renders a Default dropdown 1`] = `
       class="_trigger-button_1f39d3 _placeholder_1f39d3"
       role="combobox"
     >
-      Select an option
+      <div>
+        Select an option
+      </div>
       <svg
         class="_chevron_1f39d3"
         fill="currentColor"
@@ -243,7 +249,9 @@ exports[`Dropdown > renders a dropdown with a default value  1`] = `
       class="_trigger-button_1f39d3"
       role="combobox"
     >
-      Option 2
+      <div>
+        Option 2
+      </div>
       <svg
         class="_chevron_1f39d3"
         fill="currentColor"
@@ -325,7 +333,9 @@ exports[`Dropdown > renders a dropdown with a help label 1`] = `
       class="_trigger-button_1f39d3 _placeholder_1f39d3"
       role="combobox"
     >
-      Select an option
+      <div>
+        Select an option
+      </div>
       <svg
         class="_chevron_1f39d3"
         fill="currentColor"
@@ -401,7 +411,9 @@ exports[`Dropdown > renders a dropdown with an error  1`] = `
       class="_trigger-button_1f39d3 _placeholder_1f39d3"
       role="combobox"
     >
-      Select an option
+      <div>
+        Select an option
+      </div>
       <svg
         class="_chevron_1f39d3"
         fill="currentColor"


### PR DESCRIPTION
Allows more customisation of what gets rendered. Also make it type parameterized over the type of the values it can take so we can make stronger type assertions.

This is a breaking change although the only known usage of this component is the user status control I'm making the change for.

We could add a wrapper on top to take a simple array for the values as before, but the callback is so trivial to provide it hardly seems worth it.

Also update to use react 19 ref prop rather than forwardRef. Unfortunately this does change the indenting and therefore make the diff horrendous.