### PR TITLE
Prevent closed label tooltips from running an autoUpdate loop

### DIFF
--- a/src/components/Form/Controls/EditInPlace/__snapshots__/EditInPlace.test.tsx.snap
+++ b/src/components/Form/Controls/EditInPlace/__snapshots__/EditInPlace.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`EditInPlace > disables control when disabled 1`] = `
     >
       <label
         class="_label_af3470"
-        for="radix-_r_6o_"
+        for="radix-_r_67_"
       >
         Edit Me
       </label>
@@ -20,7 +20,7 @@ exports[`EditInPlace > disables control when disabled 1`] = `
         <input
           class="_control_958ff8"
           disabled=""
-          id="radix-_r_6o_"
+          id="radix-_r_67_"
           name="input"
           title=""
         />
@@ -40,7 +40,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 1`] = `
     >
       <label
         class="_label_af3470"
-        for="radix-_r_59_"
+        for="radix-_r_4q_"
       >
         Edit Me
       </label>
@@ -49,7 +49,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 1`] = `
       >
         <input
           class="_control_958ff8"
-          id="radix-_r_59_"
+          id="radix-_r_4q_"
           name="input"
           title=""
         />
@@ -71,7 +71,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
       <label
         class="_label_af3470"
         data-valid="true"
-        for="radix-_r_59_"
+        for="radix-_r_4q_"
       >
         Edit Me
       </label>
@@ -79,11 +79,11 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
         class="_controls_f26f0a"
       >
         <input
-          aria-describedby="radix-_r_5m_"
+          aria-describedby="radix-_r_56_"
           class="_control_958ff8"
           data-valid="true"
           disabled=""
-          id="radix-_r_59_"
+          id="radix-_r_4q_"
           name="input"
           title=""
         />
@@ -92,7 +92,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
         >
           <button
             aria-disabled="true"
-            aria-labelledby="_r_5a_"
+            aria-labelledby="_r_4r_"
             class="_button_0829c1 _has-icon_0829c1 _icon-only_0829c1"
             data-kind="primary"
             data-size="md"
@@ -116,7 +116,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
           </button>
           <button
             aria-disabled="true"
-            aria-labelledby="_r_5f_"
+            aria-labelledby="_r_50_"
             class="_button_0829c1 _button_f26f0a _has-icon_0829c1 _icon-only_0829c1"
             data-kind="secondary"
             data-size="md"
@@ -142,7 +142,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 2`] = `
       </div>
       <span
         class="_message_af3470"
-        id="radix-_r_5m_"
+        id="radix-_r_56_"
       >
         <svg
           class="_icon_8010b4"
@@ -178,7 +178,7 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 3`] = `
       <label
         class="_label_af3470"
         data-valid="true"
-        for="radix-_r_59_"
+        for="radix-_r_4q_"
       >
         Edit Me
       </label>
@@ -186,17 +186,17 @@ exports[`EditInPlace > displays saved label for 2 seconds after save 3`] = `
         class="_controls_f26f0a"
       >
         <input
-          aria-describedby="radix-_r_5n_"
+          aria-describedby="radix-_r_57_"
           class="_control_958ff8"
           data-valid="true"
-          id="radix-_r_59_"
+          id="radix-_r_4q_"
           name="input"
           title=""
         />
       </div>
       <span
         class="_message_af3470 _success-message_af3470"
-        id="radix-_r_5n_"
+        id="radix-_r_57_"
       >
         <svg
           fill="currentColor"
@@ -257,7 +257,7 @@ exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
       <label
         class="_label_af3470"
         data-invalid="true"
-        for="radix-_r_f_"
+        for="radix-_r_d_"
       >
         Edit Me
       </label>
@@ -265,11 +265,11 @@ exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
         class="_controls_f26f0a"
       >
         <input
-          aria-describedby="radix-_r_g_"
+          aria-describedby="radix-_r_e_"
           aria-invalid="true"
           class="_control_958ff8"
           data-invalid="true"
-          id="radix-_r_f_"
+          id="radix-_r_d_"
           name="input"
           title=""
         />
@@ -278,7 +278,7 @@ exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
         >
           <button
             aria-disabled="true"
-            aria-labelledby="_r_h_"
+            aria-labelledby="_r_f_"
             class="_button_0829c1 _has-icon_0829c1 _icon-only_0829c1"
             data-kind="primary"
             data-size="md"
@@ -302,7 +302,7 @@ exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-labelledby="_r_m_"
+            aria-labelledby="_r_k_"
             class="_button_0829c1 _button_f26f0a _has-icon_0829c1 _icon-only_0829c1"
             data-kind="secondary"
             data-size="md"
@@ -328,7 +328,7 @@ exports[`EditInPlace > renders error icon and text if passed as children 1`] = `
       </div>
       <span
         class="_message_af3470 _error-message_af3470"
-        id="radix-_r_g_"
+        id="radix-_r_e_"
       >
         <svg
           fill="currentColor"
@@ -358,7 +358,7 @@ exports[`EditInPlace > uses native form validation logic 1`] = `
     >
       <label
         class="_label_af3470"
-        for="radix-_r_t_"
+        for="radix-_r_p_"
       >
         Edit Me
       </label>
@@ -367,7 +367,7 @@ exports[`EditInPlace > uses native form validation logic 1`] = `
       >
         <input
           class="_control_958ff8"
-          id="radix-_r_t_"
+          id="radix-_r_p_"
           name="input"
           required=""
           title=""
@@ -389,7 +389,7 @@ exports[`EditInPlace > uses the custom error messages passed as children 1`] = `
     >
       <label
         class="_label_af3470"
-        for="radix-_r_1c_"
+        for="radix-_r_16_"
       >
         Edit Me
       </label>
@@ -398,7 +398,7 @@ exports[`EditInPlace > uses the custom error messages passed as children 1`] = `
       >
         <input
           class="_control_958ff8"
-          id="radix-_r_1c_"
+          id="radix-_r_16_"
           name="input"
           title=""
         />

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -25,6 +25,20 @@ Please see LICENSE files in the repository root for full details.
   pointer-events: none;
 }
 
+.closed-label {
+  /* Clipped rather than removed, like `.tooltip.invisible`, so that it can still act as an
+  accessible label. Unlike that one there is no floating element positioning it, so it is also
+  taken out of flow and given no size of its own, and so neither occupies space at the end of
+  the portal nor extends the page's scrollable area. */
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
 .caption {
   font-weight: var(--cpd-font-weight-regular);
   color: var(--cpd-color-text-secondary);

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -85,6 +85,29 @@ describe("Tooltip", () => {
     expect(screen.queryByRole("tooltip")).toBe(null);
   });
 
+  it("renders no floating element while a label tooltip is closed", () => {
+    render(
+      <TooltipProvider>
+        <Tooltip label="User profile" caption="Alt + P">
+          <IconButton>
+            <UserIcon />
+          </IconButton>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+    // The label and caption still reach assistive technology with the tooltip closed
+    expect(
+      screen.getByRole("button", { name: "User profile" }),
+    ).toHaveAccessibleDescription("Alt + P");
+    // but the portal holds only them: no floating element (nor its arrow) for Floating-UI to
+    // position. One would hold an autoUpdate loop for as long as it stayed mounted, attaching
+    // scroll and resize listeners to every overflow ancestor, and a virtualised list pays that
+    // per row.
+    const portal = document.querySelector("[data-floating-ui-portal]");
+    expect(portal?.querySelector("div")).toBe(null);
+    expect(portal?.querySelector("svg")).toBe(null);
+  });
+
   it("opens tooltip on focus", async () => {
     const user = userEvent.setup();
     render(

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -124,8 +124,22 @@ function TooltipContent({
     ...rest
   } = useTooltipContext();
 
-  // Label tooltips are kept in the DOM even when not visually open
-  if (!open && purpose !== "label") return null;
+  // A closed tooltip has nothing to show, but a label tooltip still supplies its anchor's
+  // accessible name, and its caption the anchor's description, so those nodes stay in the
+  // document. What they no longer need is a floating element to sit in: without one,
+  // `refs.setFloating` is never called, and Floating-UI only runs `whileElementsMounted` once both
+  // elements exist. No floating element means no `autoUpdate` loop, which eliminates scroll and resize
+  // listeners on every overflow ancestor that have a high cost in large virtualized lists.
+  //
+  // They stay in the portal rather than rendering inline next to the anchor. An anchor may be a
+  // void element, and a consumer's layout may count its children — `Switch` positions its icons
+  // with `svg:nth-child` — so a sibling span is not ours to add.
+  if (!open)
+    return purpose === "label" ? (
+      <FloatingPortal>
+        <span className={styles["closed-label"]}>{children}</span>
+      </FloatingPortal>
+    ) : null;
 
   // Hide the tooltip if it has escaped its boundary (when `boundary` prop is set)
   const escaped = floatingContext.middlewareData?.hide?.escaped ?? false;
@@ -137,9 +151,7 @@ function TooltipContent({
         style={rest.floatingStyles}
         {...rest.tooltipProps}
         {...rest.getFloatingProps()}
-        className={classNames(styles.tooltip, {
-          [styles.invisible]: (purpose === "label" && !open) || escaped,
-        })}
+        className={classNames(styles.tooltip, { [styles.invisible]: escaped })}
       >
         <FloatingArrow
           ref={arrowRef}


### PR DESCRIPTION
## Problem

A label tooltip stays in the DOM while closed, because removing the anchor's `aria-labelledby` would strip its name. Keeping
that floating element means `refs.setFloating` is still called, so Floating-UI still runs `whileElementsMounted: autoUpdate` on it. This creates scroll and resize listeners on every overflow ancestor, a `ResizeObserver` on both elements and an `IntersectionObserver`.

This is very expensive with virtualized lists that mount a tooltip per row and rebuild constantly as rows recycle. Scrolling element-web's room list starts to become noticeably slow at 50-100 items.

At 1000 rooms, moving the scroll for 5 seconds registered 30,574 scroll and resize listeners,  constructed 1,149 `IntersectionObserver`s and 635 `ResizeObserver`s; the most observed element was `div._tooltip_*._invisible_*`, at 1,373 occurrences.

Measured on a 1,000-row virtualised list at 4x CPU throttle:
| Configuration | Median frame | Long tasks | Listeners | Observers |
| --- | --- | --- | --- | --- |
| No tooltips at all (floor) | 50.7 ms | 1,674 ms | 0 | 0 |
| Today | 238.7 ms | 13,770 ms | 25,262 | 3,136 |
| **This PR** | **87.2 ms** | **5,022 ms** | **2,972** | **0** |

## The Fix

This portals the label and caption on their own, with no floating element around them. `setFloating` is never called, and Floating-UI starts `whileElementsMounted` only once both elements exist, so there is no loop to run and no arrow to position — while the same `<span id={labelId}>` stays in the tree and the anchor keeps both its accessible name and its description.

## element-web

element-web mounts these tooltips for rows the pointer is nowhere near, which I've recorded in [this issue](https://github.com/element-hq/element-web/issues/34525).
I plan a separate PR that will eliminate this tooltip mounting but I think this one is still useful as it would apply to any usage in the future, not just the specific room list case.