### PR TITLE
Always spin the InlineSpinner

### DIFF
--- a/src/components/InlineSpinner/InlineSpinner.module.css
+++ b/src/components/InlineSpinner/InlineSpinner.module.css
@@ -22,8 +22,4 @@ Please see LICENSE files in the repository root for full details.
   align-items: center;
   inline-size: 100%;
   block-size: 100%;
-
-  @media (prefers-reduced-motion: no-preference) {
-    animation: 1s linear spin infinite;
-  }
 }


### PR DESCRIPTION
Stopping the spinner when reduced motion is turned on had the unfortunate side effect of making the application look broken when not animating.

Since this animation *is* semantic, I would vote we keep it given the actual animation is quite small / unintrusive.